### PR TITLE
producer::config takes service_name for notify

### DIFF
--- a/manifests/mirror/config.pp
+++ b/manifests/mirror/config.pp
@@ -19,7 +19,8 @@ class kafka::mirror::config(
 
   class { 'kafka::producer::config':
     config          => $producer_config,
-    service_restart => $service_restart
+    service_restart => $service_restart,
+    service_name    => 'kafka-mirror'
   }
 
   create_resources('kafka::consumer::config', $consumer_config)

--- a/manifests/producer/config.pp
+++ b/manifests/producer/config.pp
@@ -9,13 +9,14 @@
 #
 class kafka::producer::config(
   $config = {},
-  $service_restart = $kafka::producer::service_restart
+  $service_restart = $kafka::producer::service_restart,
+  $service_name    = 'kafka-producer'
 ) {
 
   $producer_config = deep_merge($kafka::params::producer_config_defaults, $config)
 
   $config_notify = $service_restart ? {
-    true  => Service['kafka-producer'],
+    true  => Service[$service_name],
     false => undef
   }
 

--- a/manifests/producer/config.pp
+++ b/manifests/producer/config.pp
@@ -15,7 +15,7 @@ class kafka::producer::config(
   $producer_config = deep_merge($kafka::params::producer_config_defaults, $config)
 
   $config_notify = $service_restart ? {
-    true  => Service['kafka'],
+    true  => Service['kafka-producer'],
     false => undef
   }
 


### PR DESCRIPTION
Note this was not tested.  posting as explaination of the issue.  @liamjbennett  let me know what you think

if kafka::mirror is used and  service_restart  is not set to false then a
catalog compilation error occurs.  because producer::config will setup a
notify to a non existant service.

File[/opt/kafka/config/producer.properties] { notify => Service[kafka]
}, because Service[kafka] doesn't seem to be in the catalog

so we allow producer::config to take a service_name parameter so that when
it is used by kafka::mirror::config the correct kafka-mirror service name
can be passed.