### PR TITLE
Don't use params.pp value for install_dir

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -48,7 +48,7 @@
 class kafka::broker (
   $version = $kafka::params::version,
   $scala_version = $kafka::params::scala_version,
-  $install_dir = $kafka::params::install_dir,
+  $install_dir = '',
   $mirror_url = $kafka::params::mirror_url,
   $config = $kafka::params::broker_config_defaults,
   $install_java = $kafka::params::install_java,


### PR DESCRIPTION
See issue #9 for details of the issue.

To see why this is the right fix, consider someone using `kafka::broker` and specifying the versions of Kafka and Scala to use. At the moment, unless they specify the install directory as well, the default static value of `/opt/kafka-2.8.0-0.8.1.1` is used (i.e. `$kafka::params::install_dir`). This will be mismatched to whatever version they're trying to install.

(Practically, it's worse - it causes the symlink at `/opt/kafka` to be wrong, and it refuses to untar the package because the `creates` condition on the untar `exec` succeeds under the incorrect directory.)