### PR TITLE
Make the user broker service will run as configurable.

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -37,6 +37,12 @@
 # [*service_restart*]
 # Boolean, if the configuration files should trigger a service restart
 #
+# [*service_user*]
+# Name of user to run service as
+#
+# [*service_group*]
+# Name of group to run service as
+#
 # === Examples
 #
 # Create a single broker instance which talks to a local zookeeper instance.
@@ -53,7 +59,9 @@ class kafka::broker (
   $config = $kafka::params::broker_config_defaults,
   $install_java = $kafka::params::install_java,
   $package_dir = $kafka::params::package_dir,
-  $service_restart = $kafka::params::service_restart
+  $service_restart = $kafka::params::service_restart,
+  $service_user = $kafka::params::service_user,
+  $service_group = $kafka::params::service_group,
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")

--- a/manifests/broker/service.pp
+++ b/manifests/broker/service.pp
@@ -13,6 +13,9 @@ class kafka::broker::service {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
+  $service_user  = $::kafka::broker::service_user
+  $service_group = $::kafka::broker::service_group
+
   file { '/etc/init.d/kafka':
     ensure  => present,
     mode    => '0755',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,8 @@ class kafka::params {
   $install_dir = "/opt/kafka-${scala_version}-${version}"
 
   $service_restart = true
+  $service_user = 'kafka'
+  $service_group = 'kafka'
 
   #http://kafka.apache.org/documentation.html#brokerconfigs
   $broker_config_defaults = {

--- a/templates/init.erb
+++ b/templates/init.erb
@@ -24,7 +24,7 @@ start() {
         start
       fi
     else
-        exec sudo KAFKA_JMX_OPTS="$KAFKA_JMX_OPTS" $DAEMON $DAEMON_OPTS >> /var/log/kafka/server.log 2>&1 &
+        exec sudo -u <%= service_user %> -g <%= service_group %> KAFKA_JMX_OPTS="$KAFKA_JMX_OPTS" $DAEMON $DAEMON_OPTS >> /var/log/kafka/server.log 2>&1 &
         sleep 2
         PID=`ps ax | grep -E '[k]afka.Kafka' | awk '{print $1}'`
         echo $PID > $PID_FILE;


### PR DESCRIPTION
The puppet-kafka module uses sudo to launch all it's services but launches them all as root.  This doesn't make sense since the script can only be run as root as root typically is the only user with access to /var/run/ where the service's PID file is dropped.  Additionally, the module creates a kafka user and group.  Why bother creating the group when the service and data will be owned by root?

This is a first pass to keep my local work moving and to spark discussion about the correct way to fix this.

Note: Did not file a Jira for this because component does not exist.