### PR TITLE
Update topic.pp

### DIFF
--- a/manifests/broker/topic.pp
+++ b/manifests/broker/topic.pp
@@ -17,7 +17,7 @@ define kafka::broker::topic(
   if $ensure == 'present' {
     exec { "create topic ${name}":
       command => "/opt/kafka/bin/kafka-topics.sh --create --zookeeper '${zookeeper}' --replication-factor ${replication_factor} --partitions ${partitions} --topic ${name}",
-      unless  => "/bin/bash -c \"if [[ \\\"`/opt/kafka/bin/kafka-topics.sh --list --zookeeper '${zookeeper}' ${name}`\\\" == *${name}* ]]; then exit 0; else exit 1; fi\""
+      unless  => "/opt/kafka/bin/kafka-topics.sh --list --zookeeper ${zookeeper} | grep '^${name}\$'",
     }
   }
 }


### PR DESCRIPTION
The unless statement matched too much topics for example, if you had a 'foo' and 'foobar' topic, deleted the 'foo' topic and tried to recreate it, puppet wouldnt do it because '*foo*' still matches 'foobar'