### PR TITLE
Fix empty PID file creation on failed daemon start

### DIFF
--- a/templates/consumer.init.erb
+++ b/templates/consumer.init.erb
@@ -22,8 +22,13 @@ start() {
         exec $DAEMON $DAEMON_OPTS >> /var/log/kafka/consumer.log 2>&1 &
         sleep 2
         PID=`ps ax | grep -E '[k]afka-console-consumer' | awk '{print $1}'`
-        echo $PID > $PID_FILE;
-        echo "\n$NAME started"
+        if [ -z "$PID" ]; then
+            echo "\n $NAME could not be started"
+            exit 1
+        else
+            echo $PID > $PID_FILE;
+            echo "\n$NAME started"
+        fi
     fi
 }
 

--- a/templates/init.erb
+++ b/templates/init.erb
@@ -35,8 +35,13 @@ start() {
     /bin/su $KAFKA_USER -c "KAFKA_JMX_OPTS=\"$KAFKA_JMX_OPTS\" $DAEMON $DAEMON_OPTS > /var/log/kafka/server.out 2> /var/log/kafka/server.err &"
     sleep 2
     PID=`ps ax | grep -E '[k]afka.Kafka' | awk '{print $1}'`
-    echo $PID > $PID_FILE;
-    echo "$NAME started"
+    if [ -z "$PID" ]; then
+        echo "\n $NAME could not be started"
+        exit 1
+    else
+        echo $PID > $PID_FILE;
+        echo "\n$NAME started"
+    fi
   fi
 }
 

--- a/templates/mirror.init.erb
+++ b/templates/mirror.init.erb
@@ -25,8 +25,13 @@ start() {
     exec $DAEMON $DAEMON_OPTS >> /var/log/kafka/mirror.log 2>&1 &
     sleep 2
     PID=`ps ax | grep -E '[k]afka.tools.MirrorMaker' | awk '{print $1}'`
-    echo $PID > $PID_FILE;
-    echo "\n$NAME started"
+    if [ -z "$PID" ]; then
+        echo "\n $NAME could not be started"
+        exit 1
+    else
+        echo $PID > $PID_FILE;
+        echo "\n$NAME started"
+    fi
   fi
 }
 


### PR DESCRIPTION
When daemon cannot be started or quits to fast, then no process id can be fetched by ps and empty pid files are created.