### PR TITLE
Mirror num_streams num_producers max_heap params

### DIFF
--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -55,6 +55,8 @@ class kafka::mirror (
   $mirror_url = $kafka::params::mirror_url,
   $consumer_config = $kafka::params::consumer_config_defaults,
   $producer_config = $kafka::params::producer_config_defaults,
+  $num_streams = $kafka::params::num_streams,
+  $num_producers = $kafka::params::num_producers,
   $install_java = $kafka::params::install_java,
   $package_dir = $kafka::params::package_dir,
   $service_restart = $kafka::params::service_restart

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -31,6 +31,12 @@
 # [*producer_config*]
 # A hash of the producer configuration options.
 #
+# [*num_streams*]
+# Number of stream (consumer) threads to start.
+#
+# [*num_producers*]
+# Number of producer threads to start.
+#
 # [*install_java*]
 # Install java if it's not already installed.
 #
@@ -67,6 +73,8 @@ class kafka::mirror (
   validate_bool($install_java)
   validate_absolute_path($package_dir)
   validate_bool($service_restart)
+  validate_re($num_streams, '\d+', "'${num_streams}' is not an integer")
+  validate_re($num_producers, '\d+', "'${num_producers}' is not an integer")
 
   class { '::kafka::mirror::install': } ->
   class { '::kafka::mirror::config': } ->

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -40,6 +40,9 @@
 # [*install_java*]
 # Install java if it's not already installed.
 #
+# [*max_heap*]
+# Max heap size passed to java with -Xmx (<size>[g|G|m|M|k|K])
+#
 # [*package_dir*]
 # The directory to install kafka.
 #
@@ -64,6 +67,7 @@ class kafka::mirror (
   $num_streams = $kafka::params::num_streams,
   $num_producers = $kafka::params::num_producers,
   $install_java = $kafka::params::install_java,
+  $max_heap = $kafka::params::mirror_max_heap,
   $package_dir = $kafka::params::package_dir,
   $service_restart = $kafka::params::service_restart
 ) inherits kafka::params {
@@ -75,6 +79,7 @@ class kafka::mirror (
   validate_bool($service_restart)
   validate_re($num_streams, '\d+', "'${num_streams}' is not an integer")
   validate_re($num_producers, '\d+', "'${num_producers}' is not an integer")
+  validate_re($max_heap, '\d+[g|G|m|M|k|K]', "${max_heap} is not a valid heap size")
 
   class { '::kafka::mirror::install': } ->
   class { '::kafka::mirror::config': } ->

--- a/manifests/mirror/service.pp
+++ b/manifests/mirror/service.pp
@@ -9,9 +9,9 @@
 #
 class kafka::mirror::service(
   $consumer_configs = $kafka::params::consumer_configs,
-  $num_streams = $kafka::params::num_streams,
+  $num_streams = $kafka::mirror::num_streams,
   $producer_config = $kafka::params::producer_config,
-  $num_producers = $kafka::params::num_producers,
+  $num_producers = $kafka::mirror::num_producers,
   $whitelist = $kafka::params::whitelist,
   $blacklist = $kafka::params::blacklist
 ) {

--- a/manifests/mirror/service.pp
+++ b/manifests/mirror/service.pp
@@ -13,7 +13,8 @@ class kafka::mirror::service(
   $producer_config = $kafka::params::producer_config,
   $num_producers = $kafka::mirror::num_producers,
   $whitelist = $kafka::params::whitelist,
-  $blacklist = $kafka::params::blacklist
+  $blacklist = $kafka::params::blacklist,
+  $max_heap = $kafka::mirror::max_heap
 ) {
 
   if $caller_module_name != $module_name {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -138,6 +138,7 @@ class kafka::params {
   $producer_config = '/opt/kafka/config/producer.properties'
   $num_streams = 2
   $num_producers = 1
+  $mirror_max_heap = '256M'
   $whitelist = '.*'
   $blacklist = ''
 

--- a/templates/mirror.init.erb
+++ b/templates/mirror.init.erb
@@ -6,6 +6,9 @@ PID_FILE=/var/run/$NAME.pid
 DAEMON="/opt/kafka/bin/kafka-run-class.sh"
 DAEMON_OPTS="kafka.tools.MirrorMaker <%- @consumer_config.sort.each do |c| -%> --consumer.config /opt/kafka/config/<%= c[0] -%>.properties<%- end -%> --num.streams <%= @num_streams -%> --producer.config <%= @producer_config -%> --num.producers <%= num_producers -%><%- if !@whitelist.eql?('') -%> --whitelist=\"<%= @whitelist -%>\"<%- end %><%- if !@blacklist.eql?('') -%> --blacklist=\"<%= @blacklist -%>\"<%- end -%>"
 
+KAFKA_HEAP_OPTS="-Xmx<%= @max_heap -%>"
+export KAFKA_HEAP_OPTS
+
 start() {
   ulimit -n 65536
   ulimit -s 10240


### PR DESCRIPTION
Add following parameters to kafka::mirror

**num_streams** - number of consumer threads to start
**num_producers** - number of producer threads to start
**max_heap** - maximum Java heap size passed to -Xmx

CC: @liamjbennett 