### PR TITLE
Pin rake to avoid rubocop/rake 11 incompatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ def location_for(place, fake_version = nil)
 end
 
 group :test do
-  gem 'rake',                                                       :require => false
+  gem 'rake', '< 11',                                               :require => false
   gem 'rspec-puppet',                                               :require => false, :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem 'puppet-lint',                                                :require => false, :git => 'https://github.com/rodjek/puppet-lint.git'
   gem 'metadata-json-lint',                                         :require => false


### PR DESCRIPTION
See https://github.com/voxpupuli/modulesync_config/pull/93

This commit updates the module to our latest modulesync configuration.