### PR TITLE
Remove archive include

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,8 +118,6 @@ class kafka (
     ],
   }
 
-  include '::archive'
-
   archive { "${package_dir}/${basefilename}":
     ensure          => present,
     extract         => true,


### PR DESCRIPTION
There is no need to include archive because it's a define and not a class.
This breaks the puppet (no such module ::archive).
You can take a look at https://github.com/camptocamp/puppet-archive and see there is no need to include archive.