### PR TITLE
fix the mirror.unit template 

### DIFF
--- a/templates/mirror.unit.erb
+++ b/templates/mirror.unit.erb
@@ -11,6 +11,7 @@ Group=kafka
 SyslogIdentifier=kafka-mirror
 Environment='KAFKA_HEAP_OPTS=-Xmx<%= @max_heap -%>'
 ExecStart=/opt/kafka/bin/kafka-run-class.sh kafka.tools.MirrorMaker --consumer.config <%= @consumer_config -%> --num.streams <%= @num_streams -%> --producer.config <%= @producer_config -%><%- if (scope.function_versioncmp([scope.lookupvar('kafka::version'), '0.9.0.0']) < 0) -%> --num.producers <%= @num_producers -%><%- end -%><%- if !@whitelist.eql?('') -%> --whitelist='<%= @whitelist -%>'<%- end %><%- if !@blacklist.eql?('') -%> --blacklist='<%= @blacklist -%>'<%- end -%>
+
 LimitNOFILE=65536
 LimitCORE=infinity
 


### PR DESCRIPTION
This PR is about the mirror systemd template issue where no blacklist is provided,  whitelist does not have the -%> in the erb, and so the LimitNoFile definition is on the same like as the ExecStart, which doesn't take affect. 

The fix is just to add newline between them. simple

Before the fix it looks like this:

`/opt/kafka/bin/kafka-run-class.sh kafka.tools.MirrorMaker --consumer.config /opt/kafka/config/consumer-1.properties --num.streams 64 --producer.config /opt/kafka/config/producer.properties --num.producers 16 --whitelist='.*'LimitNOFILE=65536`

`kafka     4621     1  0 04:06 ?        00:00:04 java -Xmx256M -server -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+CMSScavengeBeforeRemark -XX:+DisableExplicitGC -Djava.awt.headless=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dkafka.logs.dir=/opt/kafka/bin/../logs -Dlog4j.configuration=file:/opt/kafka/bin/../config/tools-log4j.properties -cp :/opt/kafka/bin/../core/build/dependant-libs-2.10.4*/*.jar:/opt/kafka/bin/../examples/build/libs//kafka-examples*.jar:/opt/kafka/bin/../contrib/hadoop-consumer/build/libs//kafka-hadoop-consumer*.jar:/opt/kafka/bin/../contrib/hadoop-producer/build/libs//kafka-hadoop-producer*.jar:/opt/kafka/bin/../clients/build/libs/kafka-clients*.jar:/opt/kafka/bin/../libs/jopt-simple-3.2.jar:/opt/kafka/bin/../libs/kafka_2.10-0.8.2.1.jar:/opt/kafka/bin/../libs/kafka_2.10-0.8.2.1-javadoc.jar:/opt/kafka/bin/../libs/kafka_2.10-0.8.2.1-scaladoc.jar:/opt/kafka/bin/../libs/kafka_2.10-0.8.2.1-sources.jar:/opt/kafka/bin/../libs/kafka_2.10-0.8.2.1-test.jar:/opt/kafka/bin/../libs/kafka-clients-0.8.2.1.jar:/opt/kafka/bin/../libs/log4j-1.2.16.jar:/opt/kafka/bin/../libs/lz4-1.2.0.jar:/opt/kafka/bin/../libs/metrics-core-2.2.0.jar:/opt/kafka/bin/../libs/scala-library-2.10.4.jar:/opt/kafka/bin/../libs/slf4j-api-1.7.6.jar:/opt/kafka/bin/../libs/slf4j-log4j12-1.6.1.jar:/opt/kafka/bin/../libs/snappy-java-1.1.1.6.jar:/opt/kafka/bin/../libs/zkclient-0.3.jar:/opt/kafka/bin/../libs/zookeeper-3.4.6.jar:/opt/kafka/bin/../core/build/libs/kafka_2.10*.jar kafka.tools.MirrorMaker --consumer.config /opt/kafka/config/consumer-1.properties --num.streams xx --producer.config /opt/kafka/config/producer.properties --num.producers xx --whitelist='.*'LimitNOFILE=65536`