### PR TITLE
add the ability to optimize all the different roles, not just the broker

### DIFF
--- a/manifests/consumer.pp
+++ b/manifests/consumer.pp
@@ -45,17 +45,19 @@
 #  config => { 'client.id' => '0', 'zookeeper.connect' => 'localhost:2181' }
 # }
 class kafka::consumer (
-  $version          = $kafka::params::version,
-  $scala_version    = $kafka::params::scala_version,
-  $install_dir      = $kafka::params::install_dir,
-  $mirror_url       = $kafka::params::mirror_url,
-  $config           = {},
-  $config_defaults  = $kafka::params::consumer_config_defaults,
-  $service_config   = {},
-  $service_defaults = $kafka::params::consumer_service_defaults,
-  $install_java     = $kafka::params::install_java,
-  $package_dir      = $kafka::params::package_dir,
-  $service_restart  = $kafka::params::service_restart
+  $version               = $kafka::params::version,
+  $scala_version         = $kafka::params::scala_version,
+  $install_dir           = $kafka::params::install_dir,
+  $mirror_url            = $kafka::params::mirror_url,
+  $config                = {},
+  $config_defaults       = $kafka::params::consumer_config_defaults,
+  $service_config        = {},
+  $service_defaults      = $kafka::params::consumer_service_defaults,
+  $install_java          = $kafka::params::install_java,
+  $package_dir           = $kafka::params::package_dir,
+  $service_restart       = $kafka::params::service_restart,
+  $consumer_jmx_opts     = $kafka::params::consumer_jmx_opts,
+  $consumer_log4j_opts   = $kafka::params::consumer_log4j_opts
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -73,7 +73,9 @@ class kafka::mirror (
   $blacklist                = $kafka::params::blacklist,
   $max_heap                 = $kafka::params::mirror_max_heap,
   $package_dir              = $kafka::params::package_dir,
-  $service_restart          = $kafka::params::service_restart
+  $service_restart          = $kafka::params::service_restart,
+  $mirror_jmx_opts          = $kafka::params::mirror_jmx_opts,
+  $mirror_log4j_opts        = $kafka::params::mirror_log4j_opts
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,18 @@ class kafka::params {
   $broker_heap_opts = '-Xmx1G -Xms1G'
   $broker_log4j_opts = '-Dlog4j.configuration=file:/opt/kafka/config/log4j.properties'
 
+  $mirror_jmx_opts   = '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false \
+  -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9991'
+  $mirror_log4j_opts = $broker_log4j_opts
+
+  $producer_jmx_opts   = '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false \
+  -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9992'
+  $producer_log4j_opts = $broker_log4j_opts
+
+  $consumer_jmx_opts   = '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false \
+  -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9993'
+  $consumer_log4j_opts = $broker_log4j_opts
+
   $service_restart = true
 
   #http://kafka.apache.org/documentation.html#brokerconfigs

--- a/manifests/producer.pp
+++ b/manifests/producer.pp
@@ -47,17 +47,19 @@
 #
 class kafka::producer (
   $input,
-  $version          = $kafka::params::version,
-  $scala_version    = $kafka::params::scala_version,
-  $install_dir      = $kafka::params::install_dir,
-  $mirror_url       = $kafka::params::mirror_url,
-  $config           = {},
-  $config_defaults  = $kafka::params::producer_config_defaults,
-  $service_config   = {},
-  $service_defaults = $kafka::params::producer_service_defaults,
-  $install_java     = $kafka::params::install_java,
-  $package_dir      = $kafka::params::package_dir,
-  $service_restart  = $kafka::params::service_restart
+  $version               = $kafka::params::version,
+  $scala_version         = $kafka::params::scala_version,
+  $install_dir           = $kafka::params::install_dir,
+  $mirror_url            = $kafka::params::mirror_url,
+  $config                = {},
+  $config_defaults       = $kafka::params::producer_config_defaults,
+  $service_config        = {},
+  $service_defaults      = $kafka::params::producer_service_defaults,
+  $install_java          = $kafka::params::install_java,
+  $package_dir           = $kafka::params::package_dir,
+  $service_restart       = $kafka::params::service_restart,
+  $producer_jmx_opts     = $kafka::params::producer_jmx_opts,
+  $producer_log4j_opts   = $kafka::params::producer_log4j_opts
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")

--- a/spec/acceptance/consumer_spec.rb
+++ b/spec/acceptance/consumer_spec.rb
@@ -116,12 +116,16 @@ describe 'kafka::consumer' do
         it { is_expected.to be_file }
         it { is_expected.to be_owned_by 'root' }
         it { is_expected.to be_grouped_into 'root' }
+        it { should contain 'export KAFKA_JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false' }
+        it { should contain 'export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/log4j.properties"' }
       end
 
       describe file('/usr/lib/systemd/system/kafka-consumer.service'), if: (fact('operatingsystemmajrelease') == '7' && fact('osfamily') == 'RedHat') do
         it { is_expected.to be_file }
         it { is_expected.to be_owned_by 'root' }
         it { is_expected.to be_grouped_into 'root' }
+        it { should contain 'export KAFKA_JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false' }
+        it { should contain 'export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/log4j.properties"' }
       end
 
       describe service('kafka-consumer') do

--- a/spec/acceptance/mirror_spec.rb
+++ b/spec/acceptance/mirror_spec.rb
@@ -166,12 +166,16 @@ describe 'kafka::mirror' do
         it { is_expected.to be_file }
         it { is_expected.to be_owned_by 'root' }
         it { is_expected.to be_grouped_into 'root' }
+        it { should contain 'export KAFKA_JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false' }
+        it { should contain 'export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/log4j.properties"' }
       end
 
       describe file('/usr/lib/systemd/system/kafka-mirror.service'), if: (fact('operatingsystemmajrelease') == '7' && fact('osfamily') == 'RedHat') do
         it { is_expected.to be_file }
         it { is_expected.to be_owned_by 'root' }
         it { is_expected.to be_grouped_into 'root' }
+        it { should contain 'export KAFKA_JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false' }
+        it { should contain 'export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/log4j.properties"' }
       end
 
       describe service('kafka-mirror') do

--- a/spec/acceptance/producer_spec.rb
+++ b/spec/acceptance/producer_spec.rb
@@ -138,12 +138,16 @@ describe 'kafka::producer', if: !(fact('operatingsystemmajrelease') == '7' && fa
         it { is_expected.to be_file }
         it { is_expected.to be_owned_by 'root' }
         it { is_expected.to be_grouped_into 'root' }
+        it { should contain 'export KAFKA_JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false' }
+        it { should contain 'export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/log4j.properties"' }
       end
 
       describe file('/usr/lib/systemd/system/kafka-producer.service'), if: (fact('operatingsystemmajrelease') == '7' && fact('osfamily') == 'RedHat') do
         it { is_expected.to be_file }
         it { is_expected.to be_owned_by 'root' }
         it { is_expected.to be_grouped_into 'root' }
+        it { should contain 'export KAFKA_JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false' }
+        it { should contain 'export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/log4j.properties"' }
       end
 
       describe service('kafka-producer') do

--- a/templates/consumer.unit.erb
+++ b/templates/consumer.unit.erb
@@ -9,6 +9,8 @@ Type=simple
 User=kafka
 Group=kafka
 SyslogIdentifier=kafka-consumer
+Environment='KAFKA_LOG4J_OPTS=<%= @consumer_log4j_opts %>'
+Environment='KAFKA_JMX_OPTS=<%= @consumer_jmx_opts %>'
 ExecStart=/opt/kafka/bin/kafka-console-consumer.sh <% @consumer_service_config.sort.each do |k,v| -%><% unless v.to_s.strip.empty? -%>--<%= k -%>=<%= v %> <% end -%><% end -%>
 LimitNOFILE=65536
 LimitCORE=infinity

--- a/templates/mirror.unit.erb
+++ b/templates/mirror.unit.erb
@@ -9,6 +9,8 @@ Type=simple
 User=kafka
 Group=kafka
 SyslogIdentifier=kafka-mirror
+Environment='KAFKA_LOG4J_OPTS=<%= @mirror_log4j_opts %>'
+Environment='KAFKA_JMX_OPTS=<%= @mirror_jmx_opts %>'
 Environment='KAFKA_HEAP_OPTS=-Xmx<%= @max_heap -%>'
 ExecStart=/opt/kafka/bin/kafka-run-class.sh kafka.tools.MirrorMaker --consumer.config <%= @consumer_config -%> --num.streams <%= @num_streams -%> --producer.config <%= @producer_config -%><%- if (scope.function_versioncmp([scope.lookupvar('kafka::version'), '0.9.0.0']) < 0) -%> --num.producers <%= @num_producers -%><%- end -%><%- if !@whitelist.eql?('') -%> --whitelist='<%= @whitelist -%>'<%- end %><%- if !@blacklist.eql?('') -%> --blacklist='<%= @blacklist -%>'<%- end -%>
 

--- a/templates/producer.unit.erb
+++ b/templates/producer.unit.erb
@@ -9,6 +9,8 @@ Type=simple
 User=kafka
 Group=kafka
 SyslogIdentifier=kafka-producer
+Environment='KAFKA_LOG4J_OPTS=<%= @producer_log4j_opts %>'
+Environment='KAFKA_JMX_OPTS=<%= @producer_jmx_opts %>'
 ExecStart=/opt/kafka/bin/kafka-console-producer.sh <% @producer_service_config.sort.each do |k,v| -%><% unless v.to_s.strip.empty? -%>--<%= k -%>=<%= v %> <% end -%><% end -%> <%= @input %>
 LimitNOFILE=65536
 LimitCORE=infinity


### PR DESCRIPTION
Hi,

This module lacks the ability to, for example, set a different JMX (or at all) for the kafka mirrormaker, or set a different log4j config, etc.

This commit includes adding 3 additional sets of params, which all derives from the broker config, unless you set them - which is something you can do as all the relevant manifests are now able to receive them as variables.

By default the JMX ports are:
Broker - 9990 (No change, same as before)
Mirror - 9991
Producer - 9992
Consumer - 9993

I have encountered a situration where I have to install several components on the same host, which is one of things this commit tries to solve.

What do you think?

Thanks