### PR TITLE
Allow to set KAFKA_OPTS

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -60,6 +60,7 @@ class kafka::broker (
   $jmx_opts        = $kafka::params::broker_jmx_opts,
   $heap_opts       = $kafka::params::broker_heap_opts,
   $log4j_opts      = $kafka::params::broker_log4j_opts,
+  $opts            = $kafka::params::broker_opts,
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")

--- a/manifests/broker/service.pp
+++ b/manifests/broker/service.pp
@@ -12,6 +12,7 @@ class kafka::broker::service(
   $service_ensure  = $kafka::broker::service_ensure,
   $jmx_opts        = $kafka::broker::jmx_opts,
   $log4j_opts      = $kafka::broker::log4j_opts,
+  $opts            = $kafka::broker::opts
 ) {
 
   if $caller_module_name != $module_name {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,7 @@ class kafka::params {
   -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9990'
   $broker_heap_opts = '-Xmx1G -Xms1G'
   $broker_log4j_opts = '-Dlog4j.configuration=file:/opt/kafka/config/log4j.properties'
+  $broker_opts = ''
 
   $mirror_jmx_opts   = '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false \
   -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9991'

--- a/spec/acceptance/broker_spec.rb
+++ b/spec/acceptance/broker_spec.rb
@@ -165,7 +165,8 @@ describe 'kafka::broker' do
             },
             heap_opts  => '-Xmx512M -Xmx512M',
             log4j_opts => '-Dlog4j.configuration=file:/tmp/log4j.properties',
-            jmx_opts   => '-Dcom.sun.management.jmxremote'
+            jmx_opts   => '-Dcom.sun.management.jmxremote',
+            opts       => '-Djava.security.policy=/some/path/my.policy'
           }
         EOS
 
@@ -189,6 +190,7 @@ describe 'kafka::broker' do
         it { should contain "Environment='KAFKA_JMX_OPTS=-Dcom.sun.management.jmxremote'" }
         it { should contain "Environment='KAFKA_HEAP_OPTS=-Xmx512M -Xmx512M'" }
         it { should contain "Environment='KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:/tmp/log4j.properties'" }
+        it { should contain "Environment='KAFKA_OPTS=-Djava.security.policy=/some/path/my.policy'" }
       end
 
       describe service('kafka') do

--- a/templates/broker.unit.erb
+++ b/templates/broker.unit.erb
@@ -12,6 +12,7 @@ SyslogIdentifier=kafka
 Environment='KAFKA_HEAP_OPTS=<%= @heap_opts %>'
 Environment='KAFKA_LOG4J_OPTS=<%= @log4j_opts %>'
 Environment='KAFKA_JMX_OPTS=<%= @jmx_opts %>'
+Environment='KAFKA_OPTS=<%= @opts %>'
 ExecStart=/opt/kafka/bin/kafka-server-start.sh /opt/kafka/config/server.properties
 LimitNOFILE=65536
 LimitCORE=infinity

--- a/templates/init.erb
+++ b/templates/init.erb
@@ -21,6 +21,8 @@ export KAFKA_LOG4J_OPTS="<%= @log4j_opts %>"
 
 export KAFKA_HEAP_OPTS="<%= @heap_opts %>"
 
+export KAFKA_HEAP_OPTS="<%= @opts %>"
+
 start() {
   ulimit -n 65536
   ulimit -s 10240


### PR DESCRIPTION
Allow to send extra jvm properties to Kafka by using `KAFKA_OPTS`.

Related Kafka code (bin/kafka-run-class.sh)
```
# Launch mode
if [ "x$DAEMON_MODE" = "xtrue" ]; then
  nohup $JAVA $KAFKA_HEAP_OPTS $KAFKA_JVM_PERFORMANCE_OPTS $KAFKA_GC_LOG_OPTS $KAFKA_JMX_OPTS $KAFKA_LOG4J_OPTS -cp $CLASSPATH $KAFKA_OPTS "$@" > "$CONSOLE_OUTPUT_FILE" 2>&1 < /dev/null &
else
  exec $JAVA $KAFKA_HEAP_OPTS $KAFKA_JVM_PERFORMANCE_OPTS $KAFKA_GC_LOG_OPTS $KAFKA_JMX_OPTS $KAFKA_LOG4J_OPTS -cp $CLASSPATH $KAFKA_OPTS "$@"
fi
```

It comes in handy for instance to tweak Kafka security: `-Djava.security.policy=/some/path/my.policy`