### PR TITLE
Sync metadata.json license to be same as LICENSE (MIT)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "version": "2.0.1-rc0",
   "author": "puppet",
   "summary": "Puppet module for Kafka",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "source": "https://github.com/voxpupuli/puppet-kafka",
   "project_page": "https://github.com/voxpupuli/puppet-kafka",
   "issues_url": "https://github.com/voxpupuli/puppet-kafka/issues",


### PR DESCRIPTION
LICENSE file is MIT but metadata.json has had Apache-2.0 for
quite some time