### PR TITLE
Parameter `heap_opts`  is missing from kafka::broker::service class

### DIFF
--- a/manifests/broker/service.pp
+++ b/manifests/broker/service.pp
@@ -12,7 +12,8 @@ class kafka::broker::service(
   $service_ensure  = $kafka::broker::service_ensure,
   $jmx_opts        = $kafka::broker::jmx_opts,
   $log4j_opts      = $kafka::broker::log4j_opts,
-  $opts            = $kafka::broker::opts
+  $opts            = $kafka::broker::opts,
+  $heap_opts       = $kafka::broker::heap_opts
 ) {
 
   if $caller_module_name != $module_name {


### PR DESCRIPTION
The variable is used in the `kafka/broker.unit.erb` template but is not assigned in the kafka::broker::service class. As such, it is not propagated from the kafka::broker class, unlike $kafka::broker::opts or $kafka::broker::jmx_opts.