### PR TITLE
Fix incompatibility beetween $install_dir and $version params

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,12 +54,12 @@ class kafka (
   $basefilename = "kafka_${scala_version}-${version}.tgz"
   $package_url = "${mirror_url}/kafka/${version}/${basefilename}"
 
-  if $version != $kafka::params::version {
-    $install_directory = "/opt/kafka-${scala_version}-${version}"
-  } elsif $scala_version != $kafka::params::scala_version {
-    $install_directory = "/opt/kafka-${scala_version}-${version}"
-  } else {
-    $install_directory = $install_dir
+  $install_directory = $install_dir ? {
+    # if install_dir was not changed,
+    # we adapt it for the scala_version and the version
+    $kafka::params::install_dir => "/opt/kafka-${scala_version}-${version}",
+    # else, we just take whatever was supplied:
+    default                     => $install_dir,
   }
 
   if $install_java {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -28,4 +28,29 @@ describe 'kafka', type: :class do
       end
     end
   end
+
+  context 'on Debian' do
+    describe 'kafka' do
+      context 'all (compatible) parameters' do
+        let :params do
+          {
+            version: '0.10.0.1',
+            scala_version: '2.13',
+            install_dir: '/usr/local/kafka',
+            user_id: 9092,
+            group_id: 9092,
+            install_java: false
+          }
+        end
+        it { is_expected.to contain_group('kafka').with(gid: 9092) }
+        it { is_expected.to contain_user('kafka').with(uid: 9092) }
+
+        it { is_expected.to contain_file('/var/tmp/kafka') }
+        it { is_expected.to contain_file('/opt/kafka') }
+        it { is_expected.to contain_file('/usr/local/kafka') }
+        it { is_expected.to contain_file('/opt/kafka/config') }
+        it { is_expected.to contain_file('/var/log/kafka') }
+      end
+    end
+  end
 end


### PR DESCRIPTION
This addresses #98.

if install_dir was *not* changed, we adapt it for the potentially supplied
scala_version and kafka version

if it *was* changed, we set it, as-is.