### PR TITLE
adding the port to the mirror URL

### DIFF
--- a/.msync.yml
+++ b/.msync.yml
@@ -1,1 +1,1 @@
-modulesync_config_version: '0.13.3'
+modulesync_config_version: '0.14.1'

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :test do
   gem 'rubocop-rspec', '~> 1.6',                                    :require => false if RUBY_VERSION >= '2.3.0'
   gem 'json_pure', '<= 2.0.1',                                      :require => false if RUBY_VERSION < '2.0.0'
   gem 'mocha', '>= 1.2.1',                                          :require => false
+  gem 'coveralls',                                                  :require => false if RUBY_VERSION >= '2.0.0'
 end
 
 group :development do

--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -67,7 +67,7 @@ class kafka::broker (
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")
-  validate_re($mirror_url, '^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$', "${mirror_url} is not a valid url")
+  validate_re($mirror_url, '^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})(:[\d]{2,5})?([\/\w \.-]*)*\/?$', "${mirror_url} is not a valid url")
   validate_hash($config)
   validate_bool($install_java)
   validate_absolute_path($package_dir)

--- a/spec/acceptance/nodesets/centos-511-x64.yml
+++ b/spec/acceptance/nodesets/centos-511-x64.yml
@@ -1,4 +1,7 @@
 ---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
 HOSTS:
   centos-511-x64:
     roles:

--- a/spec/acceptance/nodesets/centos-66-x64-pe.yml
+++ b/spec/acceptance/nodesets/centos-66-x64-pe.yml
@@ -1,4 +1,7 @@
 ---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
 HOSTS:
   centos-66-x64:
     roles:

--- a/spec/acceptance/nodesets/centos-66-x64.yml
+++ b/spec/acceptance/nodesets/centos-66-x64.yml
@@ -1,4 +1,7 @@
 ---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
 HOSTS:
   centos-66-x64:
     roles:

--- a/spec/acceptance/nodesets/centos-72-x64.yml
+++ b/spec/acceptance/nodesets/centos-72-x64.yml
@@ -1,4 +1,7 @@
 ---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
 HOSTS:
   centos-72-x64:
     roles:

--- a/spec/acceptance/nodesets/debian-78-x64.yml
+++ b/spec/acceptance/nodesets/debian-78-x64.yml
@@ -1,4 +1,7 @@
 ---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
 HOSTS:
   debian-78-x64:
     roles:

--- a/spec/acceptance/nodesets/debian-82-x64.yml
+++ b/spec/acceptance/nodesets/debian-82-x64.yml
@@ -1,4 +1,7 @@
 ---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
 HOSTS:
   debian-82-x64:
     roles:

--- a/spec/acceptance/nodesets/docker/centos-5.yml
+++ b/spec/acceptance/nodesets/docker/centos-5.yml
@@ -1,0 +1,22 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+HOSTS:
+  centos-5-x64:
+    default_apply_opts:
+      order: random
+      strict_variables:
+    platform: el-5-x86_64
+    hypervisor : docker
+    image: tianon/centos:5.10
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'yum install -y crontabs tar wget which'
+      - 'sed -i -e "/mingetty/d" /etc/inittab'
+CONFIG:
+  type: aio
+  log_level: debug
+...
+# vim: syntax=yaml

--- a/spec/acceptance/nodesets/docker/centos-6.yml
+++ b/spec/acceptance/nodesets/docker/centos-6.yml
@@ -1,0 +1,23 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+HOSTS:
+  centos-6-x64:
+    default_apply_opts:
+      order: random
+      strict_variables:
+    platform: el-6-x86_64
+    hypervisor : docker
+    image: centos:6
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'rm -rf /var/run/network/*'
+      - 'yum install -y crontabs tar wget'
+      - 'rm /etc/init/tty.conf'
+CONFIG:
+  type: aio
+  log_level: debug
+...
+# vim: syntax=yaml

--- a/spec/acceptance/nodesets/docker/centos-7.yml
+++ b/spec/acceptance/nodesets/docker/centos-7.yml
@@ -1,0 +1,21 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+HOSTS:
+  centos-7-x64:
+    default_apply_opts:
+      order: random
+      strict_variables:
+    platform: el-7-x86_64
+    hypervisor : docker
+    image: centos:7
+    docker_preserve_image: true
+    docker_cmd: '["/usr/sbin/init"]'
+    docker_image_commands:
+      - 'yum install -y crontabs tar wget iproute'
+CONFIG:
+  type: aio
+  log_level: debug
+...
+# vim: syntax=yaml

--- a/spec/acceptance/nodesets/docker/debian-7.yml
+++ b/spec/acceptance/nodesets/docker/debian-7.yml
@@ -1,0 +1,21 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+HOSTS:
+  debian-7-x64:
+    default_apply_opts:
+      order: random
+      strict_variables:
+    platform: debian-7-amd64
+    hypervisor : docker
+    image: debian:7
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'apt-get install -y cron locales-all net-tools wget'
+CONFIG:
+  type: aio
+  log_level: debug
+...
+# vim: syntax=yaml

--- a/spec/acceptance/nodesets/docker/debian-8.yml
+++ b/spec/acceptance/nodesets/docker/debian-8.yml
@@ -1,0 +1,22 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+HOSTS:
+  debian-8-x64:
+    default_apply_opts:
+      order: random
+      strict_variables:
+    platform: debian-8-amd64
+    hypervisor : docker
+    image: debian:8
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'apt-get install -y cron locales-all net-tools wget'
+      - 'rm -f /usr/sbin/policy-rc.d'
+CONFIG:
+  type: aio
+  log_level: debug
+...
+# vim: syntax=yaml

--- a/spec/acceptance/nodesets/docker/ubuntu-12.04.yml
+++ b/spec/acceptance/nodesets/docker/ubuntu-12.04.yml
@@ -1,0 +1,22 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+HOSTS:
+  ubuntu-1204-x64:
+    default_apply_opts:
+      order: random
+      strict_variables:
+    platform: ubuntu-12.04-amd64
+    hypervisor : docker
+    image: ubuntu:12.04
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'apt-get install -y net-tools wget'
+      - 'locale-gen en_US.UTF-8'
+CONFIG:
+  type: aio
+  log_level: debug
+...
+# vim: syntax=yaml

--- a/spec/acceptance/nodesets/docker/ubuntu-14.04.yml
+++ b/spec/acceptance/nodesets/docker/ubuntu-14.04.yml
@@ -1,0 +1,24 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+HOSTS:
+  ubuntu-1404-x64:
+    default_apply_opts:
+      order: random
+      strict_variables:
+    platform: ubuntu-14.04-amd64
+    hypervisor : docker
+    image: ubuntu:14.04
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'rm /usr/sbin/policy-rc.d'
+      - 'rm /sbin/initctl; dpkg-divert --rename --remove /sbin/initctl'
+      - 'apt-get install -y net-tools wget'
+      - 'locale-gen en_US.UTF-8'
+CONFIG:
+  type: aio
+  log_level: debug
+...
+# vim: syntax=yaml

--- a/spec/acceptance/nodesets/docker/ubuntu-16.04.yml
+++ b/spec/acceptance/nodesets/docker/ubuntu-16.04.yml
@@ -1,0 +1,22 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+HOSTS:
+  ubuntu-1604-x64:
+    default_apply_opts:
+      order: random
+      strict_variables:
+    platform: ubuntu-16.04-amd64
+    hypervisor : docker
+    image: ubuntu:16.04
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'apt-get install -y net-tools wget'
+      - 'locale-gen en_US.UTF-8'
+CONFIG:
+  type: aio
+  log_level: debug
+...
+# vim: syntax=yaml

--- a/spec/acceptance/nodesets/ubuntu-server-1204-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-1204-x64.yml
@@ -1,4 +1,7 @@
 ---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
 HOSTS:
   ubuntu-server-1204-x64:
     roles:

--- a/spec/acceptance/nodesets/ubuntu-server-1604-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-1604-x64.yml
@@ -3,11 +3,11 @@
 # https://github.com/voxpupuli/modulesync
 # https://github.com/voxpupuli/modulesync_config
 HOSTS:
-  ubuntu-server-1404-x64:
+  ubuntu-server-1604-x64:
     roles:
       - master
-    platform: ubuntu-14.04-amd64
-    box: puppetlabs/ubuntu-14.04-64-nocm
+    platform: ubuntu-16.04-amd64
+    box: puppetlabs/ubuntu-16.04-64-nocm
     hypervisor: vagrant
 CONFIG:
   type: foss

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,11 @@ require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 include RspecPuppetFacts
 
+unless RUBY_VERSION =~ %r{^1.9}
+  require 'coveralls'
+  Coveralls.wear!
+end
+
 RSpec.configure do |c|
   default_facts = {
     puppetversion: Puppet.version,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

in some organizations where external repositories are mirrored via maven/nexus the internal mirror URL will contain the port . Right now the validation on the mirror url fails because of that. adding just minor change to the reg exp to accept the port
