### PR TITLE
Fix puppet 4 versioncmp need for string

### DIFF
--- a/manifests/broker/config.pp
+++ b/manifests/broker/config.pp
@@ -19,7 +19,8 @@ class kafka::broker::config(
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  if versioncmp($kafka::version, '0.9.0.0') < 0 {
+  $version = $kafka::version
+  if $version and versioncmp($version, '0.9.0.0') < 0 {
     if $config['broker.id'] == '-1' {
       fail('[Broker] You need to specify a value for broker.id')
     }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->
puppet 4 causes: 'versioncmp' parameter 'a' expects a String value. This PR fixes this.
