### PR TITLE
Fix bounding of puppet version in metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -62,14 +62,7 @@
     }
   ],
   "requirements": [
-    {
-      "name": "pe",
-      "version_requirement": ">= 3.2.0"
-    },
-    {
-      "name": "puppet",
-      "version_requirement": ">= 3.2.0"
-    }
+    {"name":"puppet","version_requirement":">= 3.0.0 < 5.0.0" }
   ],
   "tags": [
     "kafka",


### PR DESCRIPTION
`pe` is no longer needed and is determined based on `puppet`.