### PR TITLE
WIP: change broker.id in meta.properties

### DIFF
--- a/manifests/broker/config.pp
+++ b/manifests/broker/config.pp
@@ -38,12 +38,21 @@ class kafka::broker::config(
   }
 
   file { '/opt/kafka/config/server.properties':
-    ensure  => present,
+    ensure  => file,
     owner   => 'kafka',
     group   => 'kafka',
     mode    => '0644',
     content => template('kafka/server.properties.erb'),
     notify  => $config_notify,
     require => File['/opt/kafka/config'],
+  }
+
+  if $config['broker.id'] != '-1' {
+    file_line { 'sync_broker_id':
+      path   => "${config['log.dir']}/meta.properties",
+      match  => '^broker.id=',
+      line   => "broker=id=${config['broker.id']}",
+      notify => $config_notify,
+    }
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

This change addresses #117: when `broker.id` changes in
`server.properties`, this should also be reflected in
`$log.dir/meta.properties`. This change will currently allow the broker
to startup, should those values have gotten out of sync for which ever
reason.
However, this will *not* match up leaders/replicas in zookeeper!