### PR TITLE
Mirror url custom port

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -67,7 +67,7 @@ class kafka::broker (
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")
-  validate_re($mirror_url, '^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})(:[\d]{2,5})?([\/\w \.-]*)*\/?$', "${mirror_url} is not a valid url")
+  validate_re($mirror_url, '^(https?:\/\/)([\da-z\.-]+)\.([a-z\.]{2,6})(:[\d]{2,5})?(\/[\w \.-]*)*\/?$', "${mirror_url} is not a valid url")
   validate_hash($config)
   validate_bool($install_java)
   validate_absolute_path($package_dir)

--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -67,7 +67,7 @@ class kafka::broker (
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")
-  validate_re($mirror_url, '^(https?:\/\/)([\da-z\.-]+)\.([a-z\.]{2,6})(:[\d]{2,5})?(\/[\w \.-]*)*\/?$', "${mirror_url} is not a valid url")
+  validate_re($mirror_url, $kafka::params::mirror_url_regex, "${mirror_url} is not a valid url")
   validate_hash($config)
   validate_bool($install_java)
   validate_absolute_path($package_dir)

--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -67,7 +67,7 @@ class kafka::broker (
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")
-  validate_re($mirror_url, '^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$', "${mirror_url} is not a valid url")
+  validate_re($mirror_url, '^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})(:[\d]{2,5})?([\/\w \.-]*)*\/?$', "${mirror_url} is not a valid url")
   validate_hash($config)
   validate_bool($install_java)
   validate_absolute_path($package_dir)

--- a/manifests/consumer.pp
+++ b/manifests/consumer.pp
@@ -62,7 +62,7 @@ class kafka::consumer (
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")
-  validate_re($mirror_url, '^(https?:\/\/)([\da-z\.-]+)\.([a-z\.]{2,6})(:[\d]{2,5})?(\/[\w \.-]*)*\/?$', "${mirror_url} is not a valid url")
+  validate_re($mirror_url, $kafka::params::mirror_url_regex, "${mirror_url} is not a valid url")
   validate_bool($install_java)
   validate_absolute_path($package_dir)
   validate_bool($service_restart)

--- a/manifests/consumer.pp
+++ b/manifests/consumer.pp
@@ -62,7 +62,7 @@ class kafka::consumer (
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")
-  validate_re($mirror_url, '^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$', "${mirror_url} is not a valid url")
+  validate_re($mirror_url, '^(https?:\/\/)([\da-z\.-]+)\.([a-z\.]{2,6})(:[\d]{2,5})?(\/[\w \.-]*)*\/?$', "${mirror_url} is not a valid url")
   validate_bool($install_java)
   validate_absolute_path($package_dir)
   validate_bool($service_restart)

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -84,7 +84,7 @@ class kafka::mirror (
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")
-  validate_re($mirror_url, '^(https?:\/\/)([\da-z\.-]+)\.([a-z\.]{2,6})(:[\d]{2,5})?(\/[\w \.-]*)*\/?$', "${mirror_url} is not a valid url")
+  validate_re($mirror_url, $kafka::params::mirror_url_regex, "${mirror_url} is not a valid url")
   validate_integer($num_streams)
   validate_integer($num_producers)
   validate_bool($abort_on_send_failure)

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -84,7 +84,7 @@ class kafka::mirror (
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")
-  validate_re($mirror_url, '^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$', "${mirror_url} is not a valid url")
+  validate_re($mirror_url, '^(https?:\/\/)([\da-z\.-]+)\.([a-z\.]{2,6})(:[\d]{2,5})?(\/[\w \.-]*)*\/?$', "${mirror_url} is not a valid url")
   validate_integer($num_streams)
   validate_integer($num_producers)
   validate_bool($abort_on_send_failure)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -355,4 +355,6 @@ class kafka::params {
     'topic'                      => '',
     'value-serializer'           => 'kafka.serializer.DefaultEncoder',
   }
+
+  $mirror_url_regex = '^(https?:\/\/)([\da-z\.-]+)\.([a-z\.]{2,6})(:[\d]{2,5})?(\/[\w \.-]*)*\/?$'
 }

--- a/manifests/producer.pp
+++ b/manifests/producer.pp
@@ -64,7 +64,7 @@ class kafka::producer (
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")
-  validate_re($mirror_url, '^(https?:\/\/)([\da-z\.-]+)\.([a-z\.]{2,6})(:[\d]{2,5})?(\/[\w \.-]*)*\/?$', "${mirror_url} is not a valid url")
+  validate_re($mirror_url, $kafka::params::mirror_url_regex, "${mirror_url} is not a valid url")
   validate_bool($install_java)
   validate_absolute_path($package_dir)
   validate_bool($service_restart)

--- a/manifests/producer.pp
+++ b/manifests/producer.pp
@@ -64,7 +64,7 @@ class kafka::producer (
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")
-  validate_re($mirror_url, '^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$', "${mirror_url} is not a valid url")
+  validate_re($mirror_url, '^(https?:\/\/)([\da-z\.-]+)\.([a-z\.]{2,6})(:[\d]{2,5})?(\/[\w \.-]*)*\/?$', "${mirror_url} is not a valid url")
   validate_bool($install_java)
   validate_absolute_path($package_dir)
   validate_bool($service_restart)

--- a/spec/classes/broker_spec.rb
+++ b/spec/classes/broker_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'shared_examples_param_validation'
 
 describe 'kafka::broker', type: :class do
   let :facts do
@@ -11,12 +12,16 @@ describe 'kafka::broker', type: :class do
       service_provider: 'upstart'
     }
   end
-  let :params do
+  let :common_params do
     {
       config: {
         'zookeeper.connect' => 'localhost:2181'
       }
     }
+  end
+
+  let :params do
+    common_params
   end
 
   it { is_expected.to contain_class('kafka::broker::install').that_comes_before('Class[kafka::broker::config]') }
@@ -40,12 +45,7 @@ describe 'kafka::broker', type: :class do
     describe 'kafka::broker::service' do
       context 'service_install false' do
         let :params do
-          {
-            config: {
-              'zookeeper.connect' => 'localhost:2181'
-            },
-            service_install: false
-          }
+          common_params.merge(service_install: false)
         end
         it { is_expected.not_to contain_file('kafka.service') }
 
@@ -87,12 +87,7 @@ describe 'kafka::broker', type: :class do
     describe 'kafka::broker::service' do
       context 'service_install false' do
         let :params do
-          {
-            config: {
-              'zookeeper.connect' => 'localhost:2181'
-            },
-            service_install: false
-          }
+          common_params.merge(service_install: false)
         end
         it { is_expected.not_to contain_file('kafka.service') }
 
@@ -134,4 +129,7 @@ describe 'kafka::broker', type: :class do
       end
     end
   end
+
+  it_validates_parameter 'mirror_url'
+
 end

--- a/spec/classes/broker_spec.rb
+++ b/spec/classes/broker_spec.rb
@@ -131,5 +131,4 @@ describe 'kafka::broker', type: :class do
   end
 
   it_validates_parameter 'mirror_url'
-
 end

--- a/spec/classes/consumer_spec.rb
+++ b/spec/classes/consumer_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'shared_examples_param_validation'
 
 describe 'kafka::consumer', type: :class do
   let :facts do
@@ -12,13 +13,17 @@ describe 'kafka::consumer', type: :class do
     }
   end
 
-  let :params do
+  let :common_params do
     {
       service_config: {
         'topic'     => 'demo',
         'zookeeper' => 'localhost:2181'
       }
     }
+  end
+
+  let :params do
+    common_params
   end
 
   it { is_expected.to contain_class('kafka::consumer::install').that_comes_before('Class[kafka::consumer::service]') }
@@ -77,13 +82,7 @@ describe 'kafka::consumer', type: :class do
 
       context 'service_requires_zookeeper disabled' do
         let :params do
-          {
-            service_requires_zookeeper: false,
-            service_config: {
-              'topic'     => 'demo',
-              'zookeeper' => 'localhost:2181'
-            }
-          }
+          common_params.merge(service_requires_zookeeper: false)
         end
 
         it { should_not contain_file('kafka-consumer.service').with_content %r{^Requires=zookeeper.service$} }
@@ -91,17 +90,14 @@ describe 'kafka::consumer', type: :class do
 
       context 'service_requires_zookeeper enabled' do
         let :params do
-          {
-            service_requires_zookeeper: true,
-            service_config: {
-              'topic'     => 'demo',
-              'zookeeper' => 'localhost:2181'
-            }
-          }
+          common_params.merge(service_requires_zookeeper: true)
         end
 
         it { should contain_file('kafka-consumer.service').with_content %r{^Requires=zookeeper.service$} }
       end
     end
   end
+
+  it_validates_parameter 'mirror_url'
+
 end

--- a/spec/classes/consumer_spec.rb
+++ b/spec/classes/consumer_spec.rb
@@ -99,5 +99,4 @@ describe 'kafka::consumer', type: :class do
   end
 
   it_validates_parameter 'mirror_url'
-
 end

--- a/spec/classes/mirror_spec.rb
+++ b/spec/classes/mirror_spec.rb
@@ -12,7 +12,7 @@ describe 'kafka::mirror', type: :class do
     }
   end
 
-  let :params do
+  let :common_params do
     {
       consumer_config: {
         'group.id'          => 'kafka-mirror',
@@ -22,6 +22,10 @@ describe 'kafka::mirror', type: :class do
         'bootstrap.servers' => 'localhost:9092'
       }
     }
+  end
+
+  let :params do
+    common_params
   end
 
   it { is_expected.to contain_class('kafka::mirror::install').that_comes_before('Class[kafka::mirror::config]') }
@@ -93,16 +97,7 @@ describe 'kafka::mirror', type: :class do
 
       context 'service_requires_zookeeper disabled' do
         let :params do
-          {
-            service_requires_zookeeper: false,
-            consumer_config: {
-              'group.id'          => 'kafka-mirror',
-              'zookeeper.connect' => 'localhost:2181'
-            },
-            producer_config: {
-              'bootstrap.servers' => 'localhost:9092'
-            }
-          }
+          common_params.merge(service_requires_zookeeper: false)
         end
 
         it { should_not contain_file('kafka-mirror.service').with_content %r{^Requires=zookeeper.service$} }
@@ -110,19 +105,78 @@ describe 'kafka::mirror', type: :class do
 
       context 'service_requires_zookeeper enabled' do
         let :params do
-          {
-            service_requires_zookeeper: true,
-            consumer_config: {
-              'group.id'          => 'kafka-mirror',
-              'zookeeper.connect' => 'localhost:2181'
-            },
-            producer_config: {
-              'bootstrap.servers' => 'localhost:9092'
-            }
-          }
+          common_params.merge(service_requires_zookeeper: true)
         end
 
         it { should contain_file('kafka-mirror.service').with_content %r{^Requires=zookeeper.service$} }
+      end
+    end
+  end
+
+  context 'with mirror_url' do
+
+    domain_names = {
+      'foobar.com'  => true,
+      'foo.bar.com' => true,
+      '999.bar.com' => true,
+      'foo-bar.com' => true,
+      'no-tld'      => false,
+      'foo.longtld' => false,
+    }
+
+    prefixes = {
+      'http://'   => true,
+      'https://'  => true,
+      'random://' => false,
+    }
+
+    paths = {
+      ''                      => true,
+      '/'                     => true,
+      '/package'              => true,
+      '/package/'             => true,
+      '/another/package'      => true,
+      '/yet/another/package/' => true,
+    }
+
+    ports = {
+      ''        => true,
+      ':9'      => false,
+      ':10'     => true,
+      ':99999'  => true,
+      ':100000' => false,
+    }
+
+    prefixes.each do |prefix, valid_prefix|
+      context "with prefix <#{prefix}>" do
+
+        domain_names.each do |domain_name, valid_domain|
+          context "with domain name <#{domain_name}>" do
+
+            paths.each do |path, valid_path|
+              context "with path <#{path}>" do
+
+                ports.each do |port, valid_port|
+                  context "with port <#{port}>" do
+
+                    mirror_url = "#{prefix}#{domain_name}#{port}#{path}"
+                    context "URL => <#{mirror_url}>" do
+                      let :params do
+                        common_params.merge(mirror_url: mirror_url)
+                      end
+
+                      if valid_domain && valid_prefix && valid_path && valid_port
+                        it { is_expected.to compile }
+                      else
+                        it { expect { is_expected.to compile }.to raise_error(/#{mirror_url} is not a valid url/) }
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
       end
     end
   end

--- a/spec/classes/mirror_spec.rb
+++ b/spec/classes/mirror_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'shared_examples_param_validation'
 
 describe 'kafka::mirror', type: :class do
   let :facts do
@@ -113,71 +114,5 @@ describe 'kafka::mirror', type: :class do
     end
   end
 
-  context 'with mirror_url' do
-
-    domain_names = {
-      'foobar.com'  => true,
-      'foo.bar.com' => true,
-      '999.bar.com' => true,
-      'foo-bar.com' => true,
-      'no-tld'      => false,
-      'foo.longtld' => false,
-    }
-
-    prefixes = {
-      'http://'   => true,
-      'https://'  => true,
-      'random://' => false,
-    }
-
-    paths = {
-      ''                      => true,
-      '/'                     => true,
-      '/package'              => true,
-      '/package/'             => true,
-      '/another/package'      => true,
-      '/yet/another/package/' => true,
-    }
-
-    ports = {
-      ''        => true,
-      ':9'      => false,
-      ':10'     => true,
-      ':99999'  => true,
-      ':100000' => false,
-    }
-
-    prefixes.each do |prefix, valid_prefix|
-      context "with prefix <#{prefix}>" do
-
-        domain_names.each do |domain_name, valid_domain|
-          context "with domain name <#{domain_name}>" do
-
-            paths.each do |path, valid_path|
-              context "with path <#{path}>" do
-
-                ports.each do |port, valid_port|
-                  context "with port <#{port}>" do
-
-                    mirror_url = "#{prefix}#{domain_name}#{port}#{path}"
-                    context "URL => <#{mirror_url}>" do
-                      let :params do
-                        common_params.merge(mirror_url: mirror_url)
-                      end
-
-                      if valid_domain && valid_prefix && valid_path && valid_port
-                        it { is_expected.to compile }
-                      else
-                        it { expect { is_expected.to compile }.to raise_error(/#{mirror_url} is not a valid url/) }
-                      end
-                    end
-                  end
-                end
-              end
-            end
-          end
-        end
-      end
-    end
-  end
+  it_validates_parameter 'mirror_url'
 end

--- a/spec/classes/producer_spec.rb
+++ b/spec/classes/producer_spec.rb
@@ -74,5 +74,4 @@ describe 'kafka::producer', type: :class do
   end
 
   it_validates_parameter 'mirror_url'
-
 end

--- a/spec/classes/producer_spec.rb
+++ b/spec/classes/producer_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'shared_examples_param_validation'
 
 describe 'kafka::producer', type: :class do
   let :facts do
@@ -11,7 +12,7 @@ describe 'kafka::producer', type: :class do
       service_provider: 'upstart'
     }
   end
-  let :params do
+  let :common_params do
     {
       service_config: {
         'broker-list' => 'localhost:9092',
@@ -19,6 +20,10 @@ describe 'kafka::producer', type: :class do
       },
       input: '/tmp/kafka-producer'
     }
+  end
+
+  let :params do
+    common_params
   end
 
   it { is_expected.to contain_class('kafka::producer::install').that_comes_before('Class[kafka::producer::config]') }
@@ -67,4 +72,7 @@ describe 'kafka::producer', type: :class do
       end
     end
   end
+
+  it_validates_parameter 'mirror_url'
+
 end

--- a/spec/shared_examples_param_validation.rb
+++ b/spec/shared_examples_param_validation.rb
@@ -53,7 +53,7 @@ shared_examples 'mirror_url' do
                     if valid_domain && valid_prefix && valid_path && valid_port
                       it { is_expected.to compile }
                     else
-                      it { expect { is_expected.to compile }.to raise_error(%r(#{mirror_url} is not a valid url)) }
+                      it { expect { is_expected.to compile }.to raise_error(%r{#{mirror_url} is not a valid url}) }
                     end
                   end
                 end

--- a/spec/shared_examples_param_validation.rb
+++ b/spec/shared_examples_param_validation.rb
@@ -1,0 +1,72 @@
+
+RSpec.configure do |c|
+  c.alias_it_should_behave_like_to :it_validates_parameter, 'validates parameter:'
+end
+
+shared_examples 'mirror_url' do
+
+  domain_names = {
+    'foobar.com'  => true,
+    'foo.bar.com' => true,
+    '999.bar.com' => true,
+    'foo-bar.com' => true,
+    'no-tld'      => false,
+    'foo.longtld' => false,
+  }
+
+  prefixes = {
+    'http://'   => true,
+    'https://'  => true,
+    'random://' => false,
+  }
+
+  paths = {
+    ''                      => true,
+    '/'                     => true,
+    '/package'              => true,
+    '/package/'             => true,
+    '/another/package'      => true,
+    '/yet/another/package/' => true,
+  }
+
+  ports = {
+    ''        => true,
+    ':9'      => false,
+    ':10'     => true,
+    ':99999'  => true,
+    ':100000' => false,
+  }
+
+  prefixes.each do |prefix, valid_prefix|
+    context "with prefix <#{prefix}>" do
+
+      domain_names.each do |domain_name, valid_domain|
+        context "with domain name <#{domain_name}>" do
+
+          paths.each do |path, valid_path|
+            context "with path <#{path}>" do
+
+              ports.each do |port, valid_port|
+                context "with port <#{port}>" do
+
+                  mirror_url = "#{prefix}#{domain_name}#{port}#{path}"
+                  context "URL => <#{mirror_url}>" do
+                    let :params do
+                      common_params.merge(mirror_url: mirror_url)
+                    end
+
+                    if valid_domain && valid_prefix && valid_path && valid_port
+                      it { is_expected.to compile }
+                    else
+                      it { expect { is_expected.to compile }.to raise_error(/#{mirror_url} is not a valid url/) }
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/shared_examples_param_validation.rb
+++ b/spec/shared_examples_param_validation.rb
@@ -4,20 +4,19 @@ RSpec.configure do |c|
 end
 
 shared_examples 'mirror_url' do
-
   domain_names = {
     'foobar.com'  => true,
     'foo.bar.com' => true,
     '999.bar.com' => true,
     'foo-bar.com' => true,
     'no-tld'      => false,
-    'foo.longtld' => false,
+    'foo.longtld' => false
   }
 
   prefixes = {
     'http://'   => true,
     'https://'  => true,
-    'random://' => false,
+    'random://' => false
   }
 
   paths = {
@@ -26,7 +25,7 @@ shared_examples 'mirror_url' do
     '/package'              => true,
     '/package/'             => true,
     '/another/package'      => true,
-    '/yet/another/package/' => true,
+    '/yet/another/package/' => true
   }
 
   ports = {
@@ -34,21 +33,17 @@ shared_examples 'mirror_url' do
     ':9'      => false,
     ':10'     => true,
     ':99999'  => true,
-    ':100000' => false,
+    ':100000' => false
   }
 
   prefixes.each do |prefix, valid_prefix|
     context "with prefix <#{prefix}>" do
-
       domain_names.each do |domain_name, valid_domain|
         context "with domain name <#{domain_name}>" do
-
           paths.each do |path, valid_path|
             context "with path <#{path}>" do
-
               ports.each do |port, valid_port|
                 context "with port <#{port}>" do
-
                   mirror_url = "#{prefix}#{domain_name}#{port}#{path}"
                   context "URL => <#{mirror_url}>" do
                     let :params do
@@ -58,7 +53,7 @@ shared_examples 'mirror_url' do
                     if valid_domain && valid_prefix && valid_path && valid_port
                       it { is_expected.to compile }
                     else
-                      it { expect { is_expected.to compile }.to raise_error(/#{mirror_url} is not a valid url/) }
+                      it { expect { is_expected.to compile }.to raise_error(%r(#{mirror_url} is not a valid url)) }
                     end
                   end
                 end


### PR DESCRIPTION
- This change makes validation of mirror_url consistent across broker/producer/consumer/mirror classes, allowing any of these to include a custom port#

- It also fixes an error in the optional /path/to/package part of the original URL regex, which effectively caused the *.tld 2-6 character length restriction to be ignored.

- Tests for the various elements of the URL regex are run combinatorially – ie. every possible combination is tested.  Since these are repeated for each of the 4 dependent classes, running all unit tests takes ~5mins.  Testing a few specific sample URLs would be quicker, but risks missing some edge cases.  Really this highlights that this common validation should be extracted into a custom puppet function, unit tested once there, and mocked out in tests of dependent classes.  That’s beyond the scope of this change though.