### PR TITLE
Bump dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 0.5.0"
+      "version_requirement": ">= 1.0.0"
     },
     {
       "name": "puppetlabs/java",
@@ -26,7 +26,7 @@
     },
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 0.2.2 < 0.3.0"
+      "version_requirement": ">= 0.4.0 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
- Don't restrict the range for camptocamp/systemd
- Set minimum version for puppet/archive to 1.0.0