### PR TITLE
Add custom config dir

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -37,6 +37,9 @@
 # [*service_restart*]
 # Boolean, if the configuration files should trigger a service restart
 #
+# [*config_dir*]
+# The directory to create the kafka config files to
+#
 # === Examples
 #
 # Create a single broker instance which talks to a local zookeeper instance.
@@ -64,6 +67,7 @@ class kafka::broker (
   $opts                       = $kafka::params::broker_opts,
   $group_id                   = $kafka::params::group_id,
   $user_id                    = $kafka::params::user_id,
+  $config_dir                 = $kafka::params::config_dir,
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")

--- a/manifests/broker/config.pp
+++ b/manifests/broker/config.pp
@@ -12,7 +12,8 @@ class kafka::broker::config(
   $config_defaults = $kafka::broker::config_defaults,
   $install_dir     = $kafka::broker::install_dir,
   $service_restart = $kafka::broker::service_restart,
-  $service_install = $kafka::broker::service_install
+  $service_install = $kafka::broker::service_install,
+  $config_dir      = $kafka::broker::config_dir,
 ) {
 
   if $caller_module_name != $module_name {
@@ -37,13 +38,13 @@ class kafka::broker::config(
     $config_notify = undef
   }
 
-  file { '/opt/kafka/config/server.properties':
+  file { "${config_dir}/server.properties":
     ensure  => present,
     owner   => 'kafka',
     group   => 'kafka',
     mode    => '0644',
     content => template('kafka/server.properties.erb'),
     notify  => $config_notify,
-    require => File['/opt/kafka/config'],
+    require => File[$config_dir],
   }
 }

--- a/manifests/broker/service.pp
+++ b/manifests/broker/service.pp
@@ -15,6 +15,7 @@ class kafka::broker::service(
   $log4j_opts                 = $kafka::broker::log4j_opts,
   $heap_opts                  = $kafka::broker::heap_opts,
   $opts                       = $kafka::broker::opts,
+  $config_dir                 = $kafka::broker::config_dir,
 ) {
 
   if $caller_module_name != $module_name {

--- a/manifests/consumer.pp
+++ b/manifests/consumer.pp
@@ -37,6 +37,9 @@
 # [*service_restart*]
 # Boolean, if the configuration files should trigger a service restart
 #
+# [*config_dir*]
+# The directory to create the kafka config files to
+#
 # === Examples
 #
 # Create the consumer service connecting to a local zookeeper
@@ -58,7 +61,8 @@ class kafka::consumer (
   $service_restart            = $kafka::params::service_restart,
   $service_requires_zookeeper = $kafka::params::service_requires_zookeeper,
   $consumer_jmx_opts          = $kafka::params::consumer_jmx_opts,
-  $consumer_log4j_opts        = $kafka::params::consumer_log4j_opts
+  $consumer_log4j_opts        = $kafka::params::consumer_log4j_opts,
+  $config_dir                 = $kafka::params::config_dir,
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")

--- a/manifests/consumer/config.pp
+++ b/manifests/consumer/config.pp
@@ -11,7 +11,8 @@ define kafka::consumer::config(
   $config          = $kafka::consumer::config,
   $config_defaults = $kafka::consumer::config_defaults,
   $service_name    = 'kafka-consumer',
-  $service_restart = $kafka::consumer::service_restart
+  $service_restart = $kafka::consumer::service_restart,
+  $config_dir      = $kafka::consumer::config_dir,
 ) {
 
   $consumer_config = deep_merge($config_defaults, $config)
@@ -21,13 +22,13 @@ define kafka::consumer::config(
     default => undef
   }
 
-  file { "/opt/kafka/config/${name}.properties":
+  file { "${config_dir}/${name}.properties":
     ensure  => present,
     owner   => 'kafka',
     group   => 'kafka',
     mode    => '0644',
     content => template('kafka/consumer.properties.erb'),
     notify  => $config_notify,
-    require => File['/opt/kafka/config'],
+    require => File[$config_dir],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,9 @@
 # [*user_id*]
 # Create kafka user with this ID
 #
+# [*config_dir*]
+# The directory to create the kafka config files to
+#
 # === Examples
 #
 #
@@ -57,6 +60,7 @@ class kafka (
   $package_ensure = $kafka::params::package_ensure,
   $group_id       = $kafka::params::group_id,
   $user_id        = $kafka::params::user_id,
+  $config_dir     = $kafka::params::config_dir,
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")
@@ -123,7 +127,7 @@ class kafka (
     require => File[$install_directory],
   }
 
-  file { '/opt/kafka/config':
+  file { $config_dir:
     ensure => directory,
     owner  => 'kafka',
     group  => 'kafka',
@@ -158,12 +162,12 @@ class kafka (
         Group['kafka'],
         User['kafka'],
       ],
-      before          => File['/opt/kafka/config'],
+      before          => File[$config_dir],
     }
   } else {
     package { $package_name:
       ensure => $package_ensure,
-      before => File['/opt/kafka/config'],
+      before => File[$config_dir],
     }
   }
 }

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -52,6 +52,9 @@
 # [*service_restart*]
 # Boolean, if the configuration files should trigger a service restart
 #
+# [*config_dir*]
+# The directory to create the kafka config files to
+#
 # === Examples
 #
 # Create the mirror service connecting to a local zookeeper
@@ -80,7 +83,8 @@ class kafka::mirror (
   $service_restart            = $kafka::params::service_restart,
   $service_requires_zookeeper = $kafka::params::service_requires_zookeeper,
   $mirror_jmx_opts            = $kafka::params::mirror_jmx_opts,
-  $mirror_log4j_opts          = $kafka::params::mirror_log4j_opts
+  $mirror_log4j_opts          = $kafka::params::mirror_log4j_opts,
+  $config_dir                 = $kafka::params::config_dir,
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")

--- a/manifests/mirror/config.pp
+++ b/manifests/mirror/config.pp
@@ -12,7 +12,8 @@ class kafka::mirror::config(
   $consumer_config_defaults = $kafka::mirror::consumer_config_defaults,
   $producer_config          = $kafka::mirror::producer_config,
   $producer_config_defaults = $kafka::mirror::producer_config_defaults,
-  $service_restart          = $kafka::mirror::service_restart
+  $service_restart          = $kafka::mirror::service_restart,
+  $config_dir               = $kafka::mirror::config_dir,
 ) {
 
   if $caller_module_name != $module_name {
@@ -41,6 +42,7 @@ class kafka::mirror::config(
     config_defaults => $consumer_config_defaults,
     service_name    => 'kafka-mirror',
     service_restart => $service_restart,
+    config_dir      => $config_dir,
   }
 
   class { '::kafka::producer::config':
@@ -48,5 +50,6 @@ class kafka::mirror::config(
     config_defaults => $producer_config_defaults,
     service_name    => 'kafka-mirror',
     service_restart => $service_restart,
+    config_dir      => $config_dir,
   }
 }

--- a/manifests/mirror/service.pp
+++ b/manifests/mirror/service.pp
@@ -16,7 +16,8 @@ class kafka::mirror::service(
   $abort_on_send_failure      = $kafka::mirror::abort_on_send_failure,
   $whitelist                  = $kafka::mirror::whitelist,
   $blacklist                  = $kafka::mirror::blacklist,
-  $max_heap                   = $kafka::mirror::max_heap
+  $max_heap                   = $kafka::mirror::max_heap,
+  $config_dir                 = $kafka::params::config_dir,
 ) inherits ::kafka::params {
 
   if $caller_module_name != $module_name {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,7 @@ class kafka::params {
   $version        = '0.9.0.1'
   $scala_version  = '2.11'
   $install_dir    = "/opt/kafka-${scala_version}-${version}"
+  $config_dir     = '/opt/kafka/config'
   $mirror_url     = 'http://mirrors.ukfast.co.uk/sites/ftp.apache.org'
   $install_java   = true
   $package_dir    = '/var/tmp/kafka'
@@ -24,10 +25,11 @@ class kafka::params {
   $broker_service_install = true
   $broker_service_ensure = 'running'
 
+
   $broker_jmx_opts = '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false \
   -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9990'
   $broker_heap_opts = '-Xmx1G -Xms1G'
-  $broker_log4j_opts = '-Dlog4j.configuration=file:/opt/kafka/config/log4j.properties'
+  $broker_log4j_opts = "-Dlog4j.configuration=file:${config_dir}/log4j.properties"
   $broker_opts = ''
 
   $mirror_jmx_opts   = '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false \
@@ -308,8 +310,8 @@ class kafka::params {
 
   #https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=27846330
   #https://kafka.apache.org/documentation.html#basic_ops_mirror_maker
-  $consumer_config = '/opt/kafka/config/consumer-1.properties'
-  $producer_config = '/opt/kafka/config/producer.properties'
+  $consumer_config = "${config_dir}/consumer-1.properties"
+  $producer_config = "${config_dir}/producer.properties"
   $num_streams = 2
   $num_producers = 1
   $abort_on_send_failure = true

--- a/manifests/producer.pp
+++ b/manifests/producer.pp
@@ -37,6 +37,9 @@
 # [*service_restart*]
 # Boolean, if the configuration files should trigger a service restart
 #
+# [*config_dir*]
+# The directory to create the kafka config files to
+#
 # === Examples
 #
 # Create the producer service connecting to a local zookeeper
@@ -60,7 +63,8 @@ class kafka::producer (
   $service_restart            = $kafka::params::service_restart,
   $service_requires_zookeeper = $kafka::params::service_requires_zookeeper,
   $producer_jmx_opts          = $kafka::params::producer_jmx_opts,
-  $producer_log4j_opts        = $kafka::params::producer_log4j_opts
+  $producer_log4j_opts        = $kafka::params::producer_log4j_opts,
+  $config_dir                 = $kafka::params::config_dir,
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")

--- a/manifests/producer/config.pp
+++ b/manifests/producer/config.pp
@@ -11,7 +11,8 @@ class kafka::producer::config(
   $config          = $kafka::producer::config,
   $config_defaults = $kafka::producer::config_defaults,
   $service_name    = 'kafka-producer',
-  $service_restart = $kafka::producer::service_restart
+  $service_restart = $kafka::producer::service_restart,
+  $config_dir      = $kafka::producer::config_dir,
 ) {
 
   $producer_config = deep_merge($config_defaults, $config)
@@ -21,13 +22,13 @@ class kafka::producer::config(
     default => undef
   }
 
-  file { '/opt/kafka/config/producer.properties':
+  file { "${config_dir}/producer.properties":
     ensure  => present,
     owner   => 'kafka',
     group   => 'kafka',
     mode    => '0644',
     content => template('kafka/producer.properties.erb'),
     notify  => $config_notify,
-    require => File['/opt/kafka/config'],
+    require => File[$config_dir],
   }
 }

--- a/spec/acceptance/broker_spec.rb
+++ b/spec/acceptance/broker_spec.rb
@@ -97,6 +97,29 @@ describe 'kafka::broker' do
       end
     end
 
+    context 'with custom config dir' do
+      it 'works with no errors' do
+        pp = <<-EOS
+          class { 'zookeeper': } ->
+          class { 'kafka::broker':
+            config => {
+              'zookeeper.connect' => 'localhost:2181',
+            },
+            config_dir => '/opt/kafka/custom_config'
+          }
+        EOS
+
+        apply_manifest(pp, catch_failures: true)
+      end
+
+      describe file('/opt/kafka/custom_config/server.properties') do
+        it { is_expected.to be_file }
+        it { is_expected.to be_owned_by 'kafka' }
+        it { is_expected.to be_grouped_into 'kafka' }
+        it { is_expected.to contain 'ssl.enabled.protocols=TLSv1.2,TLSv1.1,TLSv1' }
+      end
+    end
+
     context 'with specific version' do
       it 'works with no errors' do
         pp = <<-EOS

--- a/spec/acceptance/consumer_spec.rb
+++ b/spec/acceptance/consumer_spec.rb
@@ -96,6 +96,31 @@ describe 'kafka::consumer' do
     end
   end
 
+  describe 'kafka::consumer::config' do
+    context 'with custom config_dir' do
+      it 'works with no errors' do
+        pp = <<-EOS
+          class { 'zookeeper': } ->
+          class { 'kafka::consumer':
+            service_config => {
+              topic     => 'demo',
+              zookeeper => 'localhost:2181',
+            },
+            config_dir => '/opt/kafka/custom_config',
+          }
+        EOS
+
+        apply_manifest(pp, catch_failures: true)
+      end
+
+      describe file('/opt/kafka/custom_config/consumer.properties') do
+        it { is_expected.to be_file }
+        it { is_expected.to be_owned_by 'kafka' }
+        it { is_expected.to be_grouped_into 'kafka' }
+      end
+    end
+  end
+
   describe 'kafka::consumer::service' do
     context 'with default parameters' do
       it 'works with no errors' do

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -158,5 +158,54 @@ describe 'kafka' do
         it { is_expected.to be_grouped_into 'kafka' }
       end
     end
+    context 'with specific config dir' do
+      it 'works with no errors' do
+        pp = <<-EOS
+          class { 'kafka':
+            config_dir => '/opt/kafka/custom_config',
+          }
+        EOS
+
+        apply_manifest(pp, catch_failures: true)
+      end
+
+      describe group('kafka') do
+        it { is_expected.to exist }
+      end
+
+      describe user('kafka') do
+        it { is_expected.to exist }
+        it { is_expected.to belong_to_group 'kafka' }
+        it { is_expected.to have_login_shell '/bin/bash' }
+      end
+
+      describe file('/var/tmp/kafka') do
+        it { is_expected.to be_directory }
+        it { is_expected.to be_owned_by 'kafka' }
+        it { is_expected.to be_grouped_into 'kafka' }
+      end
+
+      describe file('/opt/kafka-2.11-0.9.0.1') do
+        it { is_expected.to be_directory }
+        it { is_expected.to be_owned_by 'kafka' }
+        it { is_expected.to be_grouped_into 'kafka' }
+      end
+
+      describe file('/opt/kafka') do
+        it { is_expected.to be_linked_to('/opt/kafka-2.11-0.9.0.1') }
+      end
+
+      describe file('/opt/kafka/custom_config') do
+        it { is_expected.to be_directory }
+        it { is_expected.to be_owned_by 'kafka' }
+        it { is_expected.to be_grouped_into 'kafka' }
+      end
+
+      describe file('/var/log/kafka') do
+        it { is_expected.to be_directory }
+        it { is_expected.to be_owned_by 'kafka' }
+        it { is_expected.to be_grouped_into 'kafka' }
+      end
+    end
   end
 end

--- a/spec/acceptance/mirror_spec.rb
+++ b/spec/acceptance/mirror_spec.rb
@@ -110,6 +110,38 @@ describe 'kafka::mirror' do
       end
     end
 
+    context 'with custom config_dir' do
+      it 'works with no errors' do
+        pp = <<-EOS
+          class { 'zookeeper': } ->
+          class { 'kafka::mirror':
+            consumer_config => {
+              'group.id'          => 'kafka-mirror',
+              'zookeeper.connect' => 'localhost:2181',
+            },
+            producer_config => {
+              'bootstrap.servers' => 'localhost:9092',
+            },
+            config_dir => '/opt/kafka/custom_config'
+          }
+        EOS
+
+        apply_manifest(pp, catch_failures: true)
+      end
+
+      describe file('/opt/kafka/custom_config/consumer-1.properties') do
+        it { is_expected.to be_file }
+        it { is_expected.to be_owned_by 'kafka' }
+        it { is_expected.to be_grouped_into 'kafka' }
+      end
+
+      describe file('/opt/kafka/custom_config/producer.properties') do
+        it { is_expected.to be_file }
+        it { is_expected.to be_owned_by 'kafka' }
+        it { is_expected.to be_grouped_into 'kafka' }
+      end
+    end
+
     context 'with specific version' do
       it 'works with no errors' do
         pp = <<-EOS

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -39,7 +39,8 @@ describe 'kafka', type: :class do
             install_dir: '/usr/local/kafka',
             user_id: 9092,
             group_id: 9092,
-            install_java: false
+            install_java: false,
+            config_dir: '/opt/kafka/custom_config'
           }
         end
         it { is_expected.to contain_group('kafka').with(gid: 9092) }
@@ -48,7 +49,7 @@ describe 'kafka', type: :class do
         it { is_expected.to contain_file('/var/tmp/kafka') }
         it { is_expected.to contain_file('/opt/kafka') }
         it { is_expected.to contain_file('/usr/local/kafka') }
-        it { is_expected.to contain_file('/opt/kafka/config') }
+        it { is_expected.to contain_file('/opt/kafka/custom_config') }
         it { is_expected.to contain_file('/var/log/kafka') }
       end
     end

--- a/spec/defines/consumer_config_spec.rb
+++ b/spec/defines/consumer_config_spec.rb
@@ -18,7 +18,8 @@ describe 'kafka::consumer::config', type: :define do
         {
           'config'          => {},
           'config_defaults' => {},
-          'service_restart' => 'true'
+          'service_restart' => 'true',
+          'config_dir'      => '/opt/kafka/config'
         }
       end
 

--- a/templates/init.erb
+++ b/templates/init.erb
@@ -26,7 +26,7 @@ KAFKA_USER=kafka
 PGREP_PATTERN=kafka.Kafka
 
 DAEMON="/opt/kafka/bin/kafka-server-start.sh"
-DAEMON_OPTS="/opt/kafka/config/server.properties"
+DAEMON_OPTS="<%= @config_dir %>/server.properties"
 
 export KAFKA_JMX_OPTS="<%= @jmx_opts %>"
 export KAFKA_LOG4J_OPTS="<%= @log4j_opts %>"

--- a/templates/unit.erb
+++ b/templates/unit.erb
@@ -18,7 +18,7 @@ Environment='KAFKA_HEAP_OPTS=<%= @heap_opts %>'
 Environment='KAFKA_LOG4J_OPTS=<%= @log4j_opts %>'
 Environment='KAFKA_JMX_OPTS=<%= @jmx_opts %>'
 Environment='KAFKA_OPTS=<%= @opts %>'
-ExecStart=/opt/kafka/bin/kafka-server-start.sh /opt/kafka/config/server.properties
+ExecStart=/opt/kafka/bin/kafka-server-start.sh <%= @config_dir %>/server.properties
   <%- when 'kafka-consumer' -%>
 Environment='KAFKA_LOG4J_OPTS=<%= @consumer_log4j_opts %>'
 Environment='KAFKA_JMX_OPTS=<%= @consumer_jmx_opts %>'


### PR DESCRIPTION
Hello,

This PR allow the customization of the kafka configuration dir.
I had some issues with bundler v1.14 and ruby 1.9.3 [link](https://travis-ci.org/voxpupuli/puppet-kafka/builds/199275598). Using bundler v.1.13 everything works fine...

Thanks!

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
