### PR TITLE
Ensure the process is killed before finishing stop

### DIFF
--- a/templates/init.erb
+++ b/templates/init.erb
@@ -90,12 +90,20 @@ stop() {
     fi
   fi
 
-  kill `cat "$PID_FILE"`;
+  PID=`cat $PID_FILE`
+  kill $PID;
   rm -f -- "$PID_FILE";
 
   # wait until the process is finished
+  RETRIES=0
+  MAX_RETRIES=10
   while [ ! -z `pgrep -f "$PGREP_PATTERN"` ]; do
     sleep 1
+    RETRIES=$((RETRIES+1))
+    if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+      echo "$NAME service: stop tried $MAX_RETRIES times but process $PID is still running"
+      return 1
+    fi
   done
 
   echo "$NAME stopped"

--- a/templates/init.erb
+++ b/templates/init.erb
@@ -92,6 +92,12 @@ stop() {
 
   kill `cat "$PID_FILE"`;
   rm -f -- "$PID_FILE";
+
+  # wait until the process is finished
+  while [ ! -z `pgrep -f "$PGREP_PATTERN"` ]; do
+    sleep 1
+  done
+
   echo "$NAME stopped"
   return 0
 }


### PR DESCRIPTION
There are problems when restarting the Kafka service, it seems that the process is not effectively killed before the start phase is initiated.
I saw many checks in the start method but I think we should block the start method until Kafka is fully killed.
