### PR TITLE
modulesync 0.20.1 fixed failing unit tests

### DIFF
--- a/.msync.yml
+++ b/.msync.yml
@@ -1,1 +1,1 @@
-modulesync_config_version: '0.20.0'
+modulesync_config_version: '0.20.1'

--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ begin
   require 'github_changelog_generator/task'
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     version = (Blacksmith::Modulefile.new).version
-    config.future_release = "#{version}"
+    config.future_release = "v#{version}"
     config.header = "# Change log\n\nAll notable changes to this project will be documented in this file.\nEach new release typically also includes the latest modulesync defaults.\nThese should not impact the functionality of the module."
     config.exclude_labels = %w{duplicate question invalid wontfix modulesync}
   end

--- a/spec/acceptance/nodesets/docker/centos-7.yml
+++ b/spec/acceptance/nodesets/docker/centos-7.yml
@@ -11,6 +11,7 @@ HOSTS:
     docker_cmd: '["/usr/sbin/init"]'
     docker_image_commands:
       - 'yum install -y crontabs initscripts iproute openssl sysvinit-tools tar wget which ss'
+      - 'systemctl mask getty@tty1.service'
 CONFIG:
   trace_limit: 200
   masterless: true

--- a/spec/acceptance/nodesets/docker/debian-8.yml
+++ b/spec/acceptance/nodesets/docker/debian-8.yml
@@ -13,6 +13,7 @@ HOSTS:
       - 'echo deb http://ftp.debian.org/debian jessie-backports main >> /etc/apt/sources.list'
       - 'apt-get update && apt-get install -y cron locales-all net-tools wget'
       - 'rm -f /usr/sbin/policy-rc.d'
+      - 'systemctl mask getty@tty1.service getty-static.service'
 CONFIG:
   trace_limit: 200
   masterless: true

--- a/spec/acceptance/nodesets/ec2/amazonlinux-2016091.yml
+++ b/spec/acceptance/nodesets/ec2/amazonlinux-2016091.yml
@@ -2,7 +2,7 @@
 # This file is managed via modulesync
 # https://github.com/voxpupuli/modulesync
 # https://github.com/voxpupuli/modulesync_config
-# 
+#
 # Additional ~/.fog config file with AWS EC2 credentials
 # required.
 #

--- a/spec/acceptance/nodesets/ec2/image_templates.yaml
+++ b/spec/acceptance/nodesets/ec2/image_templates.yaml
@@ -7,7 +7,7 @@
 # Hint: image IDs (ami-*) for the same image are different per location.
 #
 AMI:
-  # Amazon Linux AMI 2016.09.1 (HVM), SSD Volume Type 
+  # Amazon Linux AMI 2016.09.1 (HVM), SSD Volume Type
   amazonlinux-2016091-eu-central-1:
     :image:
       :aio: ami-af0fc0c0

--- a/spec/acceptance/nodesets/ec2/rhel-73-x64.yml
+++ b/spec/acceptance/nodesets/ec2/rhel-73-x64.yml
@@ -2,7 +2,7 @@
 # This file is managed via modulesync
 # https://github.com/voxpupuli/modulesync
 # https://github.com/voxpupuli/modulesync_config
-# 
+#
 # Additional ~/.fog config file with AWS EC2 credentials
 # required.
 #

--- a/spec/acceptance/nodesets/ec2/sles-12sp2-x64.yml
+++ b/spec/acceptance/nodesets/ec2/sles-12sp2-x64.yml
@@ -2,7 +2,7 @@
 # This file is managed via modulesync
 # https://github.com/voxpupuli/modulesync
 # https://github.com/voxpupuli/modulesync_config
-# 
+#
 # Additional ~/.fog config file with AWS EC2 credentials
 # required.
 #

--- a/spec/acceptance/nodesets/ec2/ubuntu-1604-x64.yml
+++ b/spec/acceptance/nodesets/ec2/ubuntu-1604-x64.yml
@@ -2,7 +2,7 @@
 # This file is managed via modulesync
 # https://github.com/voxpupuli/modulesync
 # https://github.com/voxpupuli/modulesync_config
-# 
+#
 # Additional ~/.fog config file with AWS EC2 credentials
 # required.
 #

--- a/spec/acceptance/nodesets/ec2/windows-2016-base-x64.yml
+++ b/spec/acceptance/nodesets/ec2/windows-2016-base-x64.yml
@@ -2,7 +2,7 @@
 # This file is managed via modulesync
 # https://github.com/voxpupuli/modulesync
 # https://github.com/voxpupuli/modulesync_config
-# 
+#
 # Additional ~/.fog config file with AWS EC2 credentials
 # required.
 #


### PR DESCRIPTION
This pull request supersedes #136. This branch is rebased from the latest master, which fixes the failing tests. 