### PR TITLE
Fix duplicate declaration error

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ Package name, when installing kafka from a package.
 Package version (or 'present', 'absent', 'latest'), when installing kafka from
 a package.
 
+#### `manage_group`
+
+Creates group if set to true
+
+#### `manage_user`
+
+Creates user if set to true
+
 #### `group_id`
 
 Create kafka group with this ID

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,12 @@
 # [*package_ensure*]
 # Package version (or 'present', 'absent', 'latest'), when installing kafka from a package.
 #
+# [*manage_group*]
+# creates $group if set to true
+#
+# [*manage_user*]
+# creates $user if set to true
+#
 # [*group_id*]
 # Create kafka group with this ID
 #
@@ -67,6 +73,8 @@ class kafka (
   $package_dir    = $kafka::params::package_dir,
   $package_name   = $kafka::params::package_name,
   $package_ensure = $kafka::params::package_ensure,
+  $manage_group   = $kafka::params::manage_group,
+  $manage_user    = $kafka::params::manage_user,
   $group_id       = $kafka::params::group_id,
   $user_id        = $kafka::params::user_id,
   $user           = $kafka::params::user,
@@ -101,16 +109,20 @@ class kafka (
     }
   }
 
-  group { $group:
-    ensure => present,
-    gid    => $group_id,
+  if $manage_group {
+    group { $group:
+      ensure => present,
+      gid    => $group_id,
+    }
   }
 
-  user { $user:
-    ensure  => present,
-    shell   => '/bin/bash',
-    require => Group[$group],
-    uid     => $user_id,
+  if $manage_user {
+    user { $user:
+      ensure  => present,
+      shell   => '/bin/bash',
+      require => Group[$group],
+      uid     => $user_id,
+    }
   }
 
   file { $package_dir:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,8 @@ class kafka::params {
   $package_dir    = '/var/tmp/kafka'
   $package_name   = undef
   $package_ensure = 'present'
+  $manage_group   = true
+  $manage_user    = true
   $group_id       = undef
   $user_id        = undef
   $user           = 'kafka'


### PR DESCRIPTION
Hi, I was getting:
```
Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration: User[foobar] is already declared..
```
When I wanted to use already existing user, and passed it to:

```
  class { 'kafka':
    user         => 'foobar',
    group        => 'foobar',
  }
```

This should address that problem.
