### PR TITLE
Add log.message.format.version to broker params

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -127,6 +127,7 @@ class kafka::params {
     'group.max.session.timeout.ms'                  => '30000',
     'group.min.session.timeout.ms'                  => '6000',
     'inter.broker.protocol.version'                 => '0.8.2.2',
+    'log.message.format.version'                    => '0.8.2.2',
     'log.cleaner.backoff.ms'                        => '15000',
     'log.cleaner.dedupe.buffer.size'                => '134217728',
     'log.cleaner.delete.retention.ms'               => '86400000',


### PR DESCRIPTION
Patch against 3.0.0/master

When upgrading Kafka from `0.8` to `0.10`, the docs at
https://kafka.apache.org/documentation/#upgrade tell you to go gradually by upping `inter.broker.protocol.version` and `log.message.format.version`.

Not really related to #113 - but it also mentions rolling upgrades.

There's this Kafka issue that is kind of related https://issues.apache.org/jira/browse/KAFKA-3827 to this topic, but not to this PR.

**Caveat**: I only tested this with `0.8.2.2` and `0.10.2.0` (both work with this new parameter set), but not `0.9`.

`0.8.2.2` doesn't *know* the config values, so there are these warnings, but I think I didn't make it worse, as the `3.0.0` module already sets `inter.broker.protocol.version` and Kafka happily ignores it.
  * `WARN Property inter.broker.protocol.version is not valid (kafka.utils.VerifiableProperties)`
  * `WARN Property log.message.format.version is not valid (kafka.utils.VerifiableProperties)`


One thing I am not sure about is what the *default value* (if one doesn't configure it) is, per version. But as the current `log.message.format.version` is also `0.8.2.2` I think this is safe.