### PR TITLE
add support to kafka::broker logs dir

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -68,6 +68,7 @@ class kafka::broker (
   $group_id                   = $kafka::params::group_id,
   $user_id                    = $kafka::params::user_id,
   $config_dir                 = $kafka::params::config_dir,
+  $log_dir                    = $kafka::params::broker_log_dir,
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")

--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -68,7 +68,7 @@ class kafka::broker (
   $group_id                   = $kafka::params::group_id,
   $user_id                    = $kafka::params::user_id,
   $config_dir                 = $kafka::params::config_dir,
-  $log_dir                    = $kafka::params::broker_log_dir,
+  $log_dir                    = $kafka::params::log_dir,
 ) inherits kafka::params {
 
   validate_re($::osfamily, 'RedHat|Debian\b', "${::operatingsystem} not supported")

--- a/manifests/broker/service.pp
+++ b/manifests/broker/service.pp
@@ -16,6 +16,7 @@ class kafka::broker::service(
   $heap_opts                  = $kafka::broker::heap_opts,
   $opts                       = $kafka::broker::opts,
   $config_dir                 = $kafka::broker::config_dir,
+  $log_dir                    = $kafka::broker::log_dir,
 ) {
 
   if $caller_module_name != $module_name {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,6 +34,7 @@ class kafka::params {
   $broker_heap_opts = '-Xmx1G -Xms1G'
   $broker_log4j_opts = "-Dlog4j.configuration=file:${config_dir}/log4j.properties"
   $broker_opts = ''
+  $broker_log_dir = ''
 
   $mirror_jmx_opts   = '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false \
   -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9991'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,7 +34,6 @@ class kafka::params {
   $broker_heap_opts = '-Xmx1G -Xms1G'
   $broker_log4j_opts = "-Dlog4j.configuration=file:${config_dir}/log4j.properties"
   $broker_opts = ''
-  $broker_log_dir = ''
 
   $mirror_jmx_opts   = '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false \
   -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9991'

--- a/spec/acceptance/broker_spec.rb
+++ b/spec/acceptance/broker_spec.rb
@@ -227,7 +227,8 @@ describe 'kafka::broker' do
             heap_opts  => '-Xmx512M -Xmx512M',
             log4j_opts => '-Dlog4j.configuration=file:/tmp/log4j.properties',
             jmx_opts   => '-Dcom.sun.management.jmxremote',
-            opts       => '-Djava.security.policy=/some/path/my.policy'
+            opts       => '-Djava.security.policy=/some/path/my.policy',
+            log_dir    => '/some/path/to/logs'
           }
         EOS
 
@@ -252,6 +253,7 @@ describe 'kafka::broker' do
         it { is_expected.to contain "Environment='KAFKA_HEAP_OPTS=-Xmx512M -Xmx512M'" }
         it { is_expected.to contain "Environment='KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:/tmp/log4j.properties'" }
         it { is_expected.to contain "Environment='KAFKA_OPTS=-Djava.security.policy=/some/path/my.policy'" }
+        it { is_expected.to contain "Environment='LOG_DIR=/some/path/to/logs'" }
       end
 
       describe service('kafka') do

--- a/templates/init.erb
+++ b/templates/init.erb
@@ -33,6 +33,7 @@ export KAFKA_LOG4J_OPTS="<%= @log4j_opts %>"
 export KAFKA_HEAP_OPTS="<%= @heap_opts %>"
 
 export KAFKA_OPTS="<%= @opts %>"
+export LOG_DIR="<%= @log_dir %>"
 <%- when 'kafka-consumer' -%>
 PGREP_PATTERN=kafka.tools.ConsoleConsumer
 

--- a/templates/unit.erb
+++ b/templates/unit.erb
@@ -18,6 +18,7 @@ Environment='KAFKA_HEAP_OPTS=<%= @heap_opts %>'
 Environment='KAFKA_LOG4J_OPTS=<%= @log4j_opts %>'
 Environment='KAFKA_JMX_OPTS=<%= @jmx_opts %>'
 Environment='KAFKA_OPTS=<%= @opts %>'
+Environment='LOG_DIR=<%= @log_dir %>'
 ExecStart=/opt/kafka/bin/kafka-server-start.sh <%= @config_dir %>/server.properties
   <%- when 'kafka-consumer' -%>
 Environment='KAFKA_LOG4J_OPTS=<%= @consumer_log4j_opts %>'


### PR DESCRIPTION
Allow to configure Kafka app logs dir.
https://github.com/apache/kafka/blob/trunk/bin/kafka-run-class.sh:
```
# Log directory to use
if [ "x$LOG_DIR" = "x" ]; then
  LOG_DIR="$base_dir/logs"
fi
```
Despite being able to set the log4j properties file for Kafka logging, garbage collector files don't use log4j: `-Xloggc:$LOG_DIR/$GC_LOG_FILE_NAME`