### PR TITLE
the *.properties configuration files are now owned by root

### DIFF
--- a/manifests/broker/config.pp
+++ b/manifests/broker/config.pp
@@ -40,8 +40,8 @@ class kafka::broker::config(
 
   file { "${config_dir}/server.properties":
     ensure  => present,
-    owner   => 'kafka',
-    group   => 'kafka',
+    owner   => 'root',
+    group   => 'root',
     mode    => '0644',
     content => template('kafka/server.properties.erb'),
     notify  => $config_notify,

--- a/manifests/consumer/config.pp
+++ b/manifests/consumer/config.pp
@@ -24,8 +24,8 @@ define kafka::consumer::config(
 
   file { "${config_dir}/${name}.properties":
     ensure  => present,
-    owner   => 'kafka',
-    group   => 'kafka',
+    owner   => 'root',
+    group   => 'root',
     mode    => '0644',
     content => template('kafka/consumer.properties.erb'),
     notify  => $config_notify,

--- a/manifests/producer/config.pp
+++ b/manifests/producer/config.pp
@@ -24,8 +24,8 @@ class kafka::producer::config(
 
   file { "${config_dir}/producer.properties":
     ensure  => present,
-    owner   => 'kafka',
-    group   => 'kafka',
+    owner   => 'root',
+    group   => 'root',
     mode    => '0644',
     content => template('kafka/producer.properties.erb'),
     notify  => $config_notify,


### PR DESCRIPTION
This fixes https://github.com/voxpupuli/puppet-kafka/issues/165.