### PR TITLE
cleanup related to the install classes

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -25,20 +25,17 @@
 # [*mirror_url*]
 # The url where the kafka is downloaded from.
 #
-# [*env*]
-# A hash of the environment variables to set.
-#
-# [*config*]
-# A hash of the configuration options.
-#
 # [*install_java*]
 # Install java if it's not already installed.
 #
 # [*package_dir*]
 # The directory to install kafka.
 #
-# [*service_restart*]
-# Boolean, if the configuration files should trigger a service restart
+# [*package_name*]
+# Package name, when installing kafka from a package.
+#
+# [*package_ensure*]
+# Package version (or 'present', 'absent', 'latest'), when installing kafka from a package.
 #
 # [*user*]
 # User to run kafka as.
@@ -47,13 +44,31 @@
 # Group to run kafka as.
 #
 # [*user_id*]
-# Create kafka user with this ID.
+# Create the kafka user with this ID.
 #
 # [*group_id*]
-# Create kafka group with this ID.
+# Create the kafka group with this ID.
+#
+# [*manage_user*]
+# Create the kafka user if it's not already present.
+#
+# [*manage_group*]
+# Create the kafka group if it's not already present.
 #
 # [*config_dir*]
-# The directory to create the kafka config files to
+# The directory to create the kafka config files to.
+#
+# [*log_dir*]
+# The directory for kafka log files.
+#
+# [*env*]
+# A hash of the environment variables to set.
+#
+# [*config*]
+# A hash of the configuration options.
+#
+# [*service_restart*]
+# Boolean, if the configuration files should trigger a service restart
 #
 # [*bin_dir*]
 # The directory where the kafka scripts are
@@ -67,31 +82,35 @@
 # }
 #
 class kafka::broker (
-  $version                                   = $kafka::params::version,
-  $scala_version                             = $kafka::params::scala_version,
-  $install_dir                               = $kafka::params::install_dir,
+  String $version                            = $kafka::params::version,
+  String $scala_version                      = $kafka::params::scala_version,
+  Stdlib::Absolutepath $install_dir          = $kafka::params::install_dir,
   Stdlib::HTTPUrl $mirror_url                = $kafka::params::mirror_url,
-  Hash $env                                  = {},
-  Hash $config                               = {},
-  $config_defaults                           = $kafka::params::broker_config_defaults,
   Boolean $install_java                      = $kafka::params::install_java,
-  Integer $limit_nofile                      = $kafka::params::limit_nofile,
   Stdlib::Absolutepath $package_dir          = $kafka::params::package_dir,
-  Boolean $service_install                   = $kafka::params::broker_service_install,
-  Enum['running', 'stopped'] $service_ensure = $kafka::params::broker_service_ensure,
-  Boolean $service_restart                   = $kafka::params::service_restart,
-  $service_requires_zookeeper                = $kafka::params::service_requires_zookeeper,
-  $jmx_opts                                  = $kafka::params::broker_jmx_opts,
-  $heap_opts                                 = $kafka::params::broker_heap_opts,
-  $log4j_opts                                = $kafka::params::broker_log4j_opts,
-  $opts                                      = $kafka::params::broker_opts,
+  Optional[String] $package_name             = $kafka::params::package_name,
+  String $package_ensure                     = $kafka::params::package_ensure,
   String $user                               = $kafka::params::user,
   String $group                              = $kafka::params::group,
   Optional[Integer] $user_id                 = $kafka::params::user_id,
   Optional[Integer] $group_id                = $kafka::params::group_id,
-  $config_dir                                = $kafka::params::config_dir,
+  Boolean $manage_user                       = $kafka::params::manage_user,
+  Boolean $manage_group                      = $kafka::params::manage_group,
+  Stdlib::Absolutepath $config_dir           = $kafka::params::config_dir,
+  Stdlib::Absolutepath $log_dir              = $kafka::params::log_dir,
+  Hash $env                                  = {},
+  Hash $config                               = {},
+  Hash $config_defaults                      = $kafka::params::broker_config_defaults,
+  Integer $limit_nofile                      = $kafka::params::limit_nofile,
+  Boolean $service_install                   = $kafka::params::broker_service_install,
+  Enum['running', 'stopped'] $service_ensure = $kafka::params::broker_service_ensure,
+  Boolean $service_restart                   = $kafka::params::service_restart,
+  Boolean $service_requires_zookeeper        = $kafka::params::service_requires_zookeeper,
+  $jmx_opts                                  = $kafka::params::broker_jmx_opts,
+  $heap_opts                                 = $kafka::params::broker_heap_opts,
+  $log4j_opts                                = $kafka::params::broker_log4j_opts,
+  $opts                                      = $kafka::params::broker_opts,
   Stdlib::Absolutepath $bin_dir              = $kafka::params::bin_dir,
-  $log_dir                                   = $kafka::params::log_dir,
 ) inherits kafka::params {
 
   class { '::kafka::broker::install': }

--- a/manifests/broker/install.pp
+++ b/manifests/broker/install.pp
@@ -15,16 +15,22 @@ class kafka::broker::install {
 
   if !defined(Class['::kafka']) {
     class { '::kafka':
-      version       => $kafka::broker::version,
-      scala_version => $kafka::broker::scala_version,
-      install_dir   => $kafka::broker::install_dir,
-      mirror_url    => $kafka::broker::mirror_url,
-      install_java  => $kafka::broker::install_java,
-      package_dir   => $kafka::broker::package_dir,
-      user          => $kafka::broker::user,
-      group         => $kafka::broker::group,
-      user_id       => $kafka::broker::user_id,
-      group_id      => $kafka::broker::group_id,
+      version        => $kafka::broker::version,
+      scala_version  => $kafka::broker::scala_version,
+      install_dir    => $kafka::broker::install_dir,
+      mirror_url     => $kafka::broker::mirror_url,
+      install_java   => $kafka::broker::install_java,
+      package_dir    => $kafka::broker::package_dir,
+      package_name   => $kafka::broker::package_name,
+      package_ensure => $kafka::broker::package_ensure,
+      user           => $kafka::broker::user,
+      group          => $kafka::broker::group,
+      user_id        => $kafka::broker::user_id,
+      group_id       => $kafka::broker::group_id,
+      manage_user    => $kafka::broker::manage_user,
+      manage_group   => $kafka::broker::manage_group,
+      config_dir     => $kafka::broker::config_dir,
+      log_dir        => $kafka::broker::log_dir,
     }
   }
 }

--- a/manifests/consumer.pp
+++ b/manifests/consumer.pp
@@ -25,20 +25,17 @@
 # [*mirror_url*]
 # The url where the kafka is downloaded from.
 #
-# [*env*]
-# A hash of the environment variables to set.
-#
-# [*config*]
-# A hash of the consumer configuration options.
-#
 # [*install_java*]
 # Install java if it's not already installed.
 #
 # [*package_dir*]
 # The directory to install kafka.
 #
-# [*service_restart*]
-# Boolean, if the configuration files should trigger a service restart
+# [*package_name*]
+# Package name, when installing kafka from a package.
+#
+# [*package_ensure*]
+# Package version (or 'present', 'absent', 'latest'), when installing kafka from a package.
 #
 # [*user*]
 # User to run kafka as.
@@ -47,13 +44,31 @@
 # Group to run kafka as.
 #
 # [*user_id*]
-# Create kafka user with this ID.
+# Create the kafka user with this ID.
 #
 # [*group_id*]
-# Create kafka group with this ID.
+# Create the kafka group with this ID.
+#
+# [*manage_user*]
+# Create the kafka user if it's not already present.
+#
+# [*manage_group*]
+# Create the kafka group if it's not already present.
 #
 # [*config_dir*]
-# The directory to create the kafka config files to
+# The directory to create the kafka config files to.
+#
+# [*log_dir*]
+# The directory for kafka log files.
+#
+# [*env*]
+# A hash of the environment variables to set.
+#
+# [*config*]
+# A hash of the consumer configuration options.
+#
+# [*service_restart*]
+# Boolean, if the configuration files should trigger a service restart
 #
 # [*bin_dir*]
 # The directory where the kafka scripts are
@@ -66,28 +81,33 @@
 #  config => { 'client.id' => '0', 'zookeeper.connect' => 'localhost:2181' }
 # }
 class kafka::consumer (
-  $version                          = $kafka::params::version,
-  $scala_version                    = $kafka::params::scala_version,
-  $install_dir                      = $kafka::params::install_dir,
-  Stdlib::HTTPUrl $mirror_url       = $kafka::params::mirror_url,
-  Hash $env                         = {},
-  $config                           = {},
-  $config_defaults                  = $kafka::params::consumer_config_defaults,
-  $service_config                   = {},
-  $service_defaults                 = $kafka::params::consumer_service_defaults,
-  Boolean $install_java             = $kafka::params::install_java,
-  Integer $limit_nofile             = $kafka::params::limit_nofile,
-  Stdlib::Absolutepath $package_dir = $kafka::params::package_dir,
-  Boolean $service_restart          = $kafka::params::service_restart,
-  $service_requires_zookeeper       = $kafka::params::service_requires_zookeeper,
-  $consumer_jmx_opts                = $kafka::params::consumer_jmx_opts,
-  $consumer_log4j_opts              = $kafka::params::consumer_log4j_opts,
-  String $user                      = $kafka::params::user,
-  String $group                     = $kafka::params::group,
-  Optional[Integer] $user_id        = $kafka::params::user_id,
-  Optional[Integer] $group_id       = $kafka::params::group_id,
-  $config_dir                       = $kafka::params::config_dir,
-  Stdlib::Absolutepath $bin_dir     = $kafka::params::bin_dir,
+  String $version                     = $kafka::params::version,
+  String $scala_version               = $kafka::params::scala_version,
+  Stdlib::Absolutepath $install_dir   = $kafka::params::install_dir,
+  Stdlib::HTTPUrl $mirror_url         = $kafka::params::mirror_url,
+  Boolean $install_java               = $kafka::params::install_java,
+  Stdlib::Absolutepath $package_dir   = $kafka::params::package_dir,
+  Optional[String] $package_name      = $kafka::params::package_name,
+  String $package_ensure              = $kafka::params::package_ensure,
+  String $user                        = $kafka::params::user,
+  String $group                       = $kafka::params::group,
+  Optional[Integer] $user_id          = $kafka::params::user_id,
+  Optional[Integer] $group_id         = $kafka::params::group_id,
+  Boolean $manage_user                = $kafka::params::manage_user,
+  Boolean $manage_group               = $kafka::params::manage_group,
+  Stdlib::Absolutepath $config_dir    = $kafka::params::config_dir,
+  Stdlib::Absolutepath $log_dir       = $kafka::params::log_dir,
+  Hash $env                           = {},
+  Hash $config                        = {},
+  Hash $config_defaults               = $kafka::params::consumer_config_defaults,
+  Hash $service_config                = {},
+  Hash $service_defaults              = $kafka::params::consumer_service_defaults,
+  Integer $limit_nofile               = $kafka::params::limit_nofile,
+  Boolean $service_restart            = $kafka::params::service_restart,
+  Boolean $service_requires_zookeeper = $kafka::params::service_requires_zookeeper,
+  $consumer_jmx_opts                  = $kafka::params::consumer_jmx_opts,
+  $consumer_log4j_opts                = $kafka::params::consumer_log4j_opts,
+  Stdlib::Absolutepath $bin_dir       = $kafka::params::bin_dir,
 ) inherits kafka::params {
 
   class { '::kafka::consumer::install': }

--- a/manifests/consumer/install.pp
+++ b/manifests/consumer/install.pp
@@ -15,16 +15,22 @@ class kafka::consumer::install {
 
   if !defined(Class['::kafka']) {
     class { '::kafka':
-      version       => $kafka::consumer::version,
-      scala_version => $kafka::consumer::scala_version,
-      install_dir   => $kafka::consumer::install_dir,
-      mirror_url    => $kafka::consumer::mirror_url,
-      install_java  => $kafka::consumer::install_java,
-      package_dir   => $kafka::consumer::package_dir,
-      user          => $kafka::consumer::user,
-      group         => $kafka::consumer::group,
-      user_id       => $kafka::consumer::user_id,
-      group_id      => $kafka::consumer::group_id,
+      version        => $kafka::consumer::version,
+      scala_version  => $kafka::consumer::scala_version,
+      install_dir    => $kafka::consumer::install_dir,
+      mirror_url     => $kafka::consumer::mirror_url,
+      install_java   => $kafka::consumer::install_java,
+      package_dir    => $kafka::consumer::package_dir,
+      package_name   => $kafka::consumer::package_name,
+      package_ensure => $kafka::consumer::package_ensure,
+      user           => $kafka::consumer::user,
+      group          => $kafka::consumer::group,
+      user_id        => $kafka::consumer::user_id,
+      group_id       => $kafka::consumer::group_id,
+      manage_user    => $kafka::consumer::manage_user,
+      manage_group   => $kafka::consumer::manage_group,
+      config_dir     => $kafka::consumer::config_dir,
+      log_dir        => $kafka::consumer::log_dir,
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,9 +58,6 @@
 # [*config_dir*]
 # The directory to create the kafka config files to.
 #
-# [*bin_dir*]
-# The directory where the kafka scripts are.
-#
 # [*log_dir*]
 # The directory for kafka log files.
 #
@@ -68,23 +65,22 @@
 #
 #
 class kafka (
-  $version                          = $kafka::params::version,
-  $scala_version                    = $kafka::params::scala_version,
-  $install_dir                      = $kafka::params::install_dir,
+  String $version                   = $kafka::params::version,
+  String $scala_version             = $kafka::params::scala_version,
+  Stdlib::Absolutepath $install_dir = $kafka::params::install_dir,
   Stdlib::HTTPUrl $mirror_url       = $kafka::params::mirror_url,
   Boolean $install_java             = $kafka::params::install_java,
   Stdlib::Absolutepath $package_dir = $kafka::params::package_dir,
-  $package_name                     = $kafka::params::package_name,
-  $package_ensure                   = $kafka::params::package_ensure,
+  Optional[String] $package_name    = $kafka::params::package_name,
+  String $package_ensure            = $kafka::params::package_ensure,
   String $user                      = $kafka::params::user,
   String $group                     = $kafka::params::group,
   Optional[Integer] $user_id        = $kafka::params::user_id,
   Optional[Integer] $group_id       = $kafka::params::group_id,
   Boolean $manage_user              = $kafka::params::manage_user,
   Boolean $manage_group             = $kafka::params::manage_group,
-  $config_dir                       = $kafka::params::config_dir,
-  Stdlib::Absolutepath $bin_dir     = $kafka::params::bin_dir,
-  $log_dir                          = $kafka::params::log_dir,
+  Stdlib::Absolutepath $config_dir  = $kafka::params::config_dir,
+  Stdlib::Absolutepath $log_dir     = $kafka::params::log_dir,
 ) inherits kafka::params {
 
   if $install_java {

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -25,6 +25,42 @@
 # [*mirror_url*]
 # The url where the kafka is downloaded from.
 #
+# [*install_java*]
+# Install java if it's not already installed.
+#
+# [*package_dir*]
+# The directory to install kafka.
+#
+# [*package_name*]
+# Package name, when installing kafka from a package.
+#
+# [*package_ensure*]
+# Package version (or 'present', 'absent', 'latest'), when installing kafka from a package.
+#
+# [*user*]
+# User to run kafka as.
+#
+# [*group*]
+# Group to run kafka as.
+#
+# [*user_id*]
+# Create the kafka user with this ID.
+#
+# [*group_id*]
+# Create the kafka group with this ID.
+#
+# [*manage_user*]
+# Create the kafka user if it's not already present.
+#
+# [*manage_group*]
+# Create the kafka group if it's not already present.
+#
+# [*config_dir*]
+# The directory to create the kafka config files to.
+#
+# [*log_dir*]
+# The directory for kafka log files.
+#
 # [*env*]
 # A hash of the environment variables to set.
 #
@@ -43,32 +79,11 @@
 # [*abort_on_send_failure*]
 # Abort immediately if MirrorMaker fails to send to receiving cluster
 #
-# [*install_java*]
-# Install java if it's not already installed.
-#
 # [*max_heap*]
 # Max heap size passed to java with -Xmx (<size>[g|G|m|M|k|K])
 #
-# [*package_dir*]
-# The directory to install kafka.
-#
 # [*service_restart*]
 # Boolean, if the configuration files should trigger a service restart
-#
-# [*user*]
-# User to run kafka as.
-#
-# [*group*]
-# Group to run kafka as.
-#
-# [*user_id*]
-# Create kafka user with this ID.
-#
-# [*group_id*]
-# Create kafka group with this ID.
-#
-# [*config_dir*]
-# The directory to create the kafka config files to
 #
 # [*bin_dir*]
 # The directory where the kafka scripts are
@@ -82,33 +97,38 @@
 # }
 #
 class kafka::mirror (
-  $version                              = $kafka::params::version,
-  $scala_version                        = $kafka::params::scala_version,
-  $install_dir                          = $kafka::params::install_dir,
+  String $version                       = $kafka::params::version,
+  String $scala_version                 = $kafka::params::scala_version,
+  Stdlib::Absolutepath $install_dir     = $kafka::params::install_dir,
   Stdlib::HTTPUrl $mirror_url           = $kafka::params::mirror_url,
-  Hash $env                             = {},
-  $consumer_config                      = {},
-  $consumer_config_defaults             = $kafka::params::consumer_config_defaults,
-  $producer_config                      = {},
-  $producer_config_defaults             = $kafka::params::producer_config_defaults,
-  Integer $num_streams                  = $kafka::params::num_streams,
-  Integer $num_producers                = $kafka::params::num_producers,
-  Boolean $abort_on_send_failure        = $kafka::params::abort_on_send_failure,
   Boolean $install_java                 = $kafka::params::install_java,
-  Integer $limit_nofile                 = $kafka::params::limit_nofile,
-  $whitelist                            = $kafka::params::whitelist,
-  $blacklist                            = $kafka::params::blacklist,
-  Pattern[/\d+[g|G|m|M|k|K]/] $max_heap = $kafka::params::mirror_max_heap,
   Stdlib::Absolutepath $package_dir     = $kafka::params::package_dir,
-  Boolean $service_restart              = $kafka::params::service_restart,
-  $service_requires_zookeeper           = $kafka::params::service_requires_zookeeper,
-  $mirror_jmx_opts                      = $kafka::params::mirror_jmx_opts,
-  $mirror_log4j_opts                    = $kafka::params::mirror_log4j_opts,
+  Optional[String] $package_name        = $kafka::params::package_name,
+  String $package_ensure                = $kafka::params::package_ensure,
   String $user                          = $kafka::params::user,
   String $group                         = $kafka::params::group,
   Optional[Integer] $user_id            = $kafka::params::user_id,
   Optional[Integer] $group_id           = $kafka::params::group_id,
-  $config_dir                           = $kafka::params::config_dir,
+  Boolean $manage_user                  = $kafka::params::manage_user,
+  Boolean $manage_group                 = $kafka::params::manage_group,
+  Stdlib::Absolutepath $config_dir      = $kafka::params::config_dir,
+  Stdlib::Absolutepath $log_dir         = $kafka::params::log_dir,
+  Hash $env                             = {},
+  Hash $consumer_config                 = {},
+  Hash $consumer_config_defaults        = $kafka::params::consumer_config_defaults,
+  Hash $producer_config                 = {},
+  Hash $producer_config_defaults        = $kafka::params::producer_config_defaults,
+  Integer $num_streams                  = $kafka::params::num_streams,
+  Integer $num_producers                = $kafka::params::num_producers,
+  Boolean $abort_on_send_failure        = $kafka::params::abort_on_send_failure,
+  Integer $limit_nofile                 = $kafka::params::limit_nofile,
+  $whitelist                            = $kafka::params::whitelist,
+  $blacklist                            = $kafka::params::blacklist,
+  Pattern[/\d+[g|G|m|M|k|K]/] $max_heap = $kafka::params::mirror_max_heap,
+  Boolean $service_restart              = $kafka::params::service_restart,
+  Boolean $service_requires_zookeeper   = $kafka::params::service_requires_zookeeper,
+  $mirror_jmx_opts                      = $kafka::params::mirror_jmx_opts,
+  $mirror_log4j_opts                    = $kafka::params::mirror_log4j_opts,
   Stdlib::Absolutepath $bin_dir         = $kafka::params::bin_dir,
 ) inherits kafka::params {
 

--- a/manifests/mirror/install.pp
+++ b/manifests/mirror/install.pp
@@ -15,16 +15,22 @@ class kafka::mirror::install {
 
   if !defined(Class['::kafka']) {
     class { '::kafka':
-      version       => $kafka::mirror::version,
-      scala_version => $kafka::mirror::scala_version,
-      install_dir   => $kafka::mirror::install_dir,
-      mirror_url    => $kafka::mirror::mirror_url,
-      install_java  => $kafka::mirror::install_java,
-      package_dir   => $kafka::mirror::package_dir,
-      user          => $kafka::mirror::user,
-      group         => $kafka::mirror::group,
-      user_id       => $kafka::mirror::user_id,
-      group_id      => $kafka::mirror::group_id,
+      version        => $kafka::mirror::version,
+      scala_version  => $kafka::mirror::scala_version,
+      install_dir    => $kafka::mirror::install_dir,
+      mirror_url     => $kafka::mirror::mirror_url,
+      install_java   => $kafka::mirror::install_java,
+      package_dir    => $kafka::mirror::package_dir,
+      package_name   => $kafka::mirror::package_name,
+      package_ensure => $kafka::mirror::package_ensure,
+      user           => $kafka::mirror::user,
+      group          => $kafka::mirror::group,
+      user_id        => $kafka::mirror::user_id,
+      group_id       => $kafka::mirror::group_id,
+      manage_user    => $kafka::mirror::manage_user,
+      manage_group   => $kafka::mirror::manage_group,
+      config_dir     => $kafka::mirror::config_dir,
+      log_dir        => $kafka::mirror::log_dir,
     }
   }
 }

--- a/manifests/producer.pp
+++ b/manifests/producer.pp
@@ -25,20 +25,17 @@
 # [*mirror_url*]
 # The url where the kafka is downloaded from.
 #
-# [*env*]
-# A hash of the environment variables to set.
-#
-# [*config*]
-# A hash of the producer configuration options.
-#
 # [*install_java*]
 # Install java if it's not already installed.
 #
 # [*package_dir*]
 # The directory to install kafka.
 #
-# [*service_restart*]
-# Boolean, if the configuration files should trigger a service restart
+# [*package_name*]
+# Package name, when installing kafka from a package.
+#
+# [*package_ensure*]
+# Package version (or 'present', 'absent', 'latest'), when installing kafka from a package.
 #
 # [*user*]
 # User to run kafka as.
@@ -47,13 +44,31 @@
 # Group to run kafka as.
 #
 # [*user_id*]
-# Create kafka user with this ID.
+# Create the kafka user with this ID.
 #
 # [*group_id*]
-# Create kafka group with this ID.
+# Create the kafka group with this ID.
+#
+# [*manage_user*]
+# Create the kafka user if it's not already present.
+#
+# [*manage_group*]
+# Create the kafka group if it's not already present.
 #
 # [*config_dir*]
-# The directory to create the kafka config files to
+# The directory to create the kafka config files to.
+#
+# [*log_dir*]
+# The directory for kafka log files.
+#
+# [*env*]
+# A hash of the environment variables to set.
+#
+# [*config*]
+# A hash of the producer configuration options.
+#
+# [*service_restart*]
+# Boolean, if the configuration files should trigger a service restart
 #
 # [*bin_dir*]
 # The directory where the kafka scripts are
@@ -68,27 +83,32 @@
 #
 class kafka::producer (
   $input,
-  $version                          = $kafka::params::version,
-  $scala_version                    = $kafka::params::scala_version,
-  $install_dir                      = $kafka::params::install_dir,
-  Stdlib::HTTPUrl $mirror_url       = $kafka::params::mirror_url,
-  Hash $env                         = {},
-  $config                           = {},
-  $config_defaults                  = $kafka::params::producer_config_defaults,
-  $service_config                   = {},
-  $service_defaults                 = $kafka::params::producer_service_defaults,
-  Boolean $install_java             = $kafka::params::install_java,
-  Stdlib::Absolutepath $package_dir = $kafka::params::package_dir,
-  Boolean $service_restart          = $kafka::params::service_restart,
-  $service_requires_zookeeper       = $kafka::params::service_requires_zookeeper,
-  $producer_jmx_opts                = $kafka::params::producer_jmx_opts,
-  $producer_log4j_opts              = $kafka::params::producer_log4j_opts,
-  String $user                      = $kafka::params::user,
-  String $group                     = $kafka::params::group,
-  Optional[Integer] $user_id        = $kafka::params::user_id,
-  Optional[Integer] $group_id       = $kafka::params::group_id,
-  $config_dir                       = $kafka::params::config_dir,
-  Stdlib::Absolutepath $bin_dir     = $kafka::params::bin_dir,
+  String $version                     = $kafka::params::version,
+  String $scala_version               = $kafka::params::scala_version,
+  Stdlib::Absolutepath $install_dir   = $kafka::params::install_dir,
+  Stdlib::HTTPUrl $mirror_url         = $kafka::params::mirror_url,
+  Boolean $install_java               = $kafka::params::install_java,
+  Stdlib::Absolutepath $package_dir   = $kafka::params::package_dir,
+  Optional[String] $package_name      = $kafka::params::package_name,
+  String $package_ensure              = $kafka::params::package_ensure,
+  String $user                        = $kafka::params::user,
+  String $group                       = $kafka::params::group,
+  Optional[Integer] $user_id          = $kafka::params::user_id,
+  Optional[Integer] $group_id         = $kafka::params::group_id,
+  Boolean $manage_user                = $kafka::params::manage_user,
+  Boolean $manage_group               = $kafka::params::manage_group,
+  Stdlib::Absolutepath $config_dir    = $kafka::params::config_dir,
+  Stdlib::Absolutepath $log_dir       = $kafka::params::log_dir,
+  Hash $env                           = {},
+  Hash $config                        = {},
+  Hash $config_defaults               = $kafka::params::producer_config_defaults,
+  Hash $service_config                = {},
+  Hash $service_defaults              = $kafka::params::producer_service_defaults,
+  Boolean $service_restart            = $kafka::params::service_restart,
+  Boolean $service_requires_zookeeper = $kafka::params::service_requires_zookeeper,
+  $producer_jmx_opts                  = $kafka::params::producer_jmx_opts,
+  $producer_log4j_opts                = $kafka::params::producer_log4j_opts,
+  Stdlib::Absolutepath $bin_dir       = $kafka::params::bin_dir,
 ) inherits kafka::params {
 
   class { '::kafka::producer::install': }

--- a/manifests/producer/install.pp
+++ b/manifests/producer/install.pp
@@ -15,16 +15,22 @@ class kafka::producer::install {
 
   if !defined(Class['::kafka']) {
     class { '::kafka':
-      version       => $kafka::producer::version,
-      scala_version => $kafka::producer::scala_version,
-      install_dir   => $kafka::producer::install_dir,
-      mirror_url    => $kafka::producer::mirror_url,
-      install_java  => $kafka::producer::install_java,
-      package_dir   => $kafka::producer::package_dir,
-      user          => $kafka::producer::user,
-      group         => $kafka::producer::group,
-      user_id       => $kafka::producer::user_id,
-      group_id      => $kafka::producer::group_id,
+      version        => $kafka::producer::version,
+      scala_version  => $kafka::producer::scala_version,
+      install_dir    => $kafka::producer::install_dir,
+      mirror_url     => $kafka::producer::mirror_url,
+      install_java   => $kafka::producer::install_java,
+      package_dir    => $kafka::producer::package_dir,
+      package_name   => $kafka::producer::package_name,
+      package_ensure => $kafka::producer::package_ensure,
+      user           => $kafka::producer::user,
+      group          => $kafka::producer::group,
+      user_id        => $kafka::producer::user_id,
+      group_id       => $kafka::producer::group_id,
+      manage_user    => $kafka::producer::manage_user,
+      manage_group   => $kafka::producer::manage_group,
+      config_dir     => $kafka::producer::config_dir,
+      log_dir        => $kafka::producer::log_dir,
     }
   }
 }


### PR DESCRIPTION
kafka::init:
 - removed the unused $bin_dir parameter
 - added the missing types

kafka::{broker,consumer,mirror,producer}:
 - made sure all kafka::init parameters are present (in order) and documented
 - added some missing types

kafka::{broker,consumer,mirror,producer}::install:
 - made sure all kafka::init parameters are passed

This fixes https://github.com/voxpupuli/puppet-kafka/issues/190.