### PR TITLE
cleanup related to the service classes

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -61,17 +61,32 @@
 # [*log_dir*]
 # The directory for kafka log files.
 #
+# [*bin_dir*]
+# The directory where the kafka scripts are.
+#
+# [*service_name*]
+# Set the name of the service.
+#
+# [*service_install*]
+# Install the init.d or systemd service.
+#
+# [*service_ensure*]
+# Set the ensure state of the service to 'stopped' or 'running'.
+#
+# [*service_restart*]
+# Whether the configuration files should trigger a service restart.
+#
+# [*service_requires_zookeeper*]
+# Whether the service should require the ZooKeeper service.
+#
+# [*limit_nofile*]
+# Set the 'LimitNOFILE' option of the systemd service.
+#
 # [*env*]
 # A hash of the environment variables to set.
 #
 # [*config*]
 # A hash of the configuration options.
-#
-# [*service_restart*]
-# Boolean, if the configuration files should trigger a service restart
-#
-# [*bin_dir*]
-# The directory where the kafka scripts are
 #
 # === Examples
 #
@@ -98,19 +113,20 @@ class kafka::broker (
   Boolean $manage_group                      = $kafka::params::manage_group,
   Stdlib::Absolutepath $config_dir           = $kafka::params::config_dir,
   Stdlib::Absolutepath $log_dir              = $kafka::params::log_dir,
+  Stdlib::Absolutepath $bin_dir              = $kafka::params::bin_dir,
+  String $service_name                       = 'kafka',
+  Boolean $service_install                   = $kafka::params::service_install,
+  Enum['running', 'stopped'] $service_ensure = $kafka::params::service_ensure,
+  Boolean $service_restart                   = $kafka::params::service_restart,
+  Boolean $service_requires_zookeeper        = $kafka::params::service_requires_zookeeper,
+  Integer $limit_nofile                      = $kafka::params::limit_nofile,
   Hash $env                                  = {},
   Hash $config                               = {},
   Hash $config_defaults                      = $kafka::params::broker_config_defaults,
-  Integer $limit_nofile                      = $kafka::params::limit_nofile,
-  Boolean $service_install                   = $kafka::params::broker_service_install,
-  Enum['running', 'stopped'] $service_ensure = $kafka::params::broker_service_ensure,
-  Boolean $service_restart                   = $kafka::params::service_restart,
-  Boolean $service_requires_zookeeper        = $kafka::params::service_requires_zookeeper,
   $jmx_opts                                  = $kafka::params::broker_jmx_opts,
   $heap_opts                                 = $kafka::params::broker_heap_opts,
   $log4j_opts                                = $kafka::params::broker_log4j_opts,
   $opts                                      = $kafka::params::broker_opts,
-  Stdlib::Absolutepath $bin_dir              = $kafka::params::bin_dir,
 ) inherits kafka::params {
 
   class { '::kafka::broker::install': }

--- a/manifests/broker/config.pp
+++ b/manifests/broker/config.pp
@@ -8,12 +8,12 @@
 # It manages the broker config files
 #
 class kafka::broker::config(
-  $config          = $kafka::broker::config,
-  $config_defaults = $kafka::broker::config_defaults,
-  $install_dir     = $kafka::broker::install_dir,
-  $service_restart = $kafka::broker::service_restart,
-  $service_install = $kafka::broker::service_install,
-  $config_dir      = $kafka::broker::config_dir,
+  Stdlib::Absolutepath $config_dir = $kafka::broker::config_dir,
+  String $service_name             = $kafka::broker::service_name,
+  Boolean $service_install         = $kafka::broker::service_install,
+  Boolean $service_restart         = $kafka::broker::service_restart,
+  Hash $config                     = $kafka::broker::config,
+  Hash $config_defaults            = $kafka::broker::config_defaults,
 ) {
 
   if $caller_module_name != $module_name {
@@ -29,11 +29,8 @@ class kafka::broker::config(
 
   $server_config = deep_merge($config_defaults, $config)
 
-  if $service_install {
-    $config_notify = $service_restart ? {
-      true  => Service['kafka'],
-      false => undef
-    }
+  if ($service_install and $service_restart) {
+    $config_notify = Service[$service_name]
   } else {
     $config_notify = undef
   }

--- a/manifests/broker/service.pp
+++ b/manifests/broker/service.pp
@@ -42,9 +42,8 @@ class kafka::broker::service(
     if $::service_provider == 'systemd' {
       include ::systemd
 
-      file { "${service_name}.service":
+      file { "/etc/systemd/system/${service_name}.service":
         ensure  => file,
-        path    => "/etc/systemd/system/${service_name}.service",
         mode    => '0644',
         content => template('kafka/unit.erb'),
       }
@@ -58,9 +57,8 @@ class kafka::broker::service(
       -> Service[$service_name]
 
     } else {
-      file { "${service_name}.service":
+      file { "/etc/init.d/${service_name}":
         ensure  => file,
-        path    => "/etc/init.d/${service_name}",
         mode    => '0755',
         content => template('kafka/init.erb'),
         before  => Service[$service_name],

--- a/manifests/broker/service.pp
+++ b/manifests/broker/service.pp
@@ -8,37 +8,37 @@
 # It manages the kafka service
 #
 class kafka::broker::service(
-  $service_install              = $kafka::broker::service_install,
-  $service_ensure               = $kafka::broker::service_ensure,
-  $service_requires_zookeeper   = $kafka::broker::service_requires_zookeeper,
-  $jmx_opts                     = $kafka::broker::jmx_opts,
-  $limit_nofile                 = $kafka::broker::limit_nofile,
-  $log4j_opts                   = $kafka::broker::log4j_opts,
-  $heap_opts                    = $kafka::broker::heap_opts,
-  $opts                         = $kafka::broker::opts,
-  Hash $env                     = $kafka::broker::env,
-  $config_dir                   = $kafka::broker::config_dir,
-  Stdlib::Absolutepath $bin_dir = $kafka::broker::bin_dir,
-  $log_dir                      = $kafka::broker::log_dir,
-  String $user                  = $kafka::broker::user,
-  String $group                 = $kafka::broker::group,
+  String $user                               = $kafka::broker::user,
+  String $group                              = $kafka::broker::group,
+  Stdlib::Absolutepath $config_dir           = $kafka::broker::config_dir,
+  Stdlib::Absolutepath $log_dir              = $kafka::broker::log_dir,
+  Stdlib::Absolutepath $bin_dir              = $kafka::broker::bin_dir,
+  String $service_name                       = $kafka::broker::service_name,
+  Boolean $service_install                   = $kafka::broker::service_install,
+  Enum['running', 'stopped'] $service_ensure = $kafka::broker::service_ensure,
+  Boolean $service_requires_zookeeper        = $kafka::broker::service_requires_zookeeper,
+  Integer $limit_nofile                      = $kafka::broker::limit_nofile,
+  Hash $env                                  = $kafka::broker::env,
+  $jmx_opts                                  = $kafka::broker::jmx_opts,
+  $log4j_opts                                = $kafka::broker::log4j_opts,
+  $heap_opts                                 = $kafka::broker::heap_opts,
+  $opts                                      = $kafka::broker::opts,
 ) {
 
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  $service_name = 'kafka'
-  $env_defaults = {
-    'KAFKA_HEAP_OPTS'  => $heap_opts,
-    'KAFKA_LOG4J_OPTS' => $log4j_opts,
-    'KAFKA_JMX_OPTS'   => $jmx_opts,
-    'KAFKA_OPTS'       => $opts,
-    'LOG_DIR'          => $log_dir,
-  }
-  $environment = deep_merge($env_defaults, $env)
-
   if $service_install {
+    $env_defaults = {
+      'KAFKA_HEAP_OPTS'  => $heap_opts,
+      'KAFKA_LOG4J_OPTS' => $log4j_opts,
+      'KAFKA_JMX_OPTS'   => $jmx_opts,
+      'KAFKA_OPTS'       => $opts,
+      'LOG_DIR'          => $log_dir,
+    }
+    $environment = deep_merge($env_defaults, $env)
+
     if $::service_provider == 'systemd' {
       include ::systemd
 
@@ -73,7 +73,5 @@ class kafka::broker::service(
       hasstatus  => true,
       hasrestart => true,
     }
-  } else {
-    debug('Skipping service install')
   }
 }

--- a/manifests/broker/service.pp
+++ b/manifests/broker/service.pp
@@ -52,7 +52,7 @@ class kafka::broker::service(
         ensure => absent,
       }
 
-      File["${service_name}.service"]
+      File["/etc/systemd/system/${service_name}.service"]
       ~> Exec['systemctl-daemon-reload']
       -> Service[$service_name]
 

--- a/manifests/consumer.pp
+++ b/manifests/consumer.pp
@@ -61,17 +61,32 @@
 # [*log_dir*]
 # The directory for kafka log files.
 #
+# [*bin_dir*]
+# The directory where the kafka scripts are.
+#
+# [*service_name*]
+# Set the name of the service.
+#
+# [*service_install*]
+# Install the init.d or systemd service.
+#
+# [*service_ensure*]
+# Set the ensure state of the service to 'stopped' or 'running'.
+#
+# [*service_restart*]
+# Whether the configuration files should trigger a service restart.
+#
+# [*service_requires_zookeeper*]
+# Whether the service should require the ZooKeeper service.
+#
+# [*limit_nofile*]
+# Set the 'LimitNOFILE' option of the systemd service.
+#
 # [*env*]
 # A hash of the environment variables to set.
 #
 # [*config*]
 # A hash of the consumer configuration options.
-#
-# [*service_restart*]
-# Boolean, if the configuration files should trigger a service restart
-#
-# [*bin_dir*]
-# The directory where the kafka scripts are
 #
 # === Examples
 #
@@ -81,33 +96,36 @@
 #  config => { 'client.id' => '0', 'zookeeper.connect' => 'localhost:2181' }
 # }
 class kafka::consumer (
-  String $version                     = $kafka::params::version,
-  String $scala_version               = $kafka::params::scala_version,
-  Stdlib::Absolutepath $install_dir   = $kafka::params::install_dir,
-  Stdlib::HTTPUrl $mirror_url         = $kafka::params::mirror_url,
-  Boolean $install_java               = $kafka::params::install_java,
-  Stdlib::Absolutepath $package_dir   = $kafka::params::package_dir,
-  Optional[String] $package_name      = $kafka::params::package_name,
-  String $package_ensure              = $kafka::params::package_ensure,
-  String $user                        = $kafka::params::user,
-  String $group                       = $kafka::params::group,
-  Optional[Integer] $user_id          = $kafka::params::user_id,
-  Optional[Integer] $group_id         = $kafka::params::group_id,
-  Boolean $manage_user                = $kafka::params::manage_user,
-  Boolean $manage_group               = $kafka::params::manage_group,
-  Stdlib::Absolutepath $config_dir    = $kafka::params::config_dir,
-  Stdlib::Absolutepath $log_dir       = $kafka::params::log_dir,
-  Hash $env                           = {},
-  Hash $config                        = {},
-  Hash $config_defaults               = $kafka::params::consumer_config_defaults,
-  Hash $service_config                = {},
-  Hash $service_defaults              = $kafka::params::consumer_service_defaults,
-  Integer $limit_nofile               = $kafka::params::limit_nofile,
-  Boolean $service_restart            = $kafka::params::service_restart,
-  Boolean $service_requires_zookeeper = $kafka::params::service_requires_zookeeper,
-  $consumer_jmx_opts                  = $kafka::params::consumer_jmx_opts,
-  $consumer_log4j_opts                = $kafka::params::consumer_log4j_opts,
-  Stdlib::Absolutepath $bin_dir       = $kafka::params::bin_dir,
+  String $version                            = $kafka::params::version,
+  String $scala_version                      = $kafka::params::scala_version,
+  Stdlib::Absolutepath $install_dir          = $kafka::params::install_dir,
+  Stdlib::HTTPUrl $mirror_url                = $kafka::params::mirror_url,
+  Boolean $install_java                      = $kafka::params::install_java,
+  Stdlib::Absolutepath $package_dir          = $kafka::params::package_dir,
+  Optional[String] $package_name             = $kafka::params::package_name,
+  String $package_ensure                     = $kafka::params::package_ensure,
+  String $user                               = $kafka::params::user,
+  String $group                              = $kafka::params::group,
+  Optional[Integer] $user_id                 = $kafka::params::user_id,
+  Optional[Integer] $group_id                = $kafka::params::group_id,
+  Boolean $manage_user                       = $kafka::params::manage_user,
+  Boolean $manage_group                      = $kafka::params::manage_group,
+  Stdlib::Absolutepath $config_dir           = $kafka::params::config_dir,
+  Stdlib::Absolutepath $log_dir              = $kafka::params::log_dir,
+  Stdlib::Absolutepath $bin_dir              = $kafka::params::bin_dir,
+  String $service_name                       = 'kafka-consumer',
+  Boolean $service_install                   = $kafka::params::service_install,
+  Enum['running', 'stopped'] $service_ensure = $kafka::params::service_ensure,
+  Boolean $service_restart                   = $kafka::params::service_restart,
+  Boolean $service_requires_zookeeper        = $kafka::params::service_requires_zookeeper,
+  Integer $limit_nofile                      = $kafka::params::limit_nofile,
+  Hash $env                                  = {},
+  Hash $config                               = {},
+  Hash $config_defaults                      = $kafka::params::consumer_config_defaults,
+  Hash $service_config                       = {},
+  Hash $service_defaults                     = $kafka::params::consumer_service_defaults,
+  $consumer_jmx_opts                         = $kafka::params::consumer_jmx_opts,
+  $consumer_log4j_opts                       = $kafka::params::consumer_log4j_opts,
 ) inherits kafka::params {
 
   class { '::kafka::consumer::install': }

--- a/manifests/consumer/config.pp
+++ b/manifests/consumer/config.pp
@@ -8,18 +8,20 @@
 # It manages the consumer config files
 #
 class kafka::consumer::config(
-  $config          = $kafka::consumer::config,
-  $config_defaults = $kafka::consumer::config_defaults,
-  $service_name    = 'kafka-consumer',
-  $service_restart = $kafka::consumer::service_restart,
-  $config_dir      = $kafka::consumer::config_dir,
+  Stdlib::Absolutepath $config_dir = $kafka::consumer::config_dir,
+  String $service_name             = $kafka::consumer::service_name,
+  Boolean $service_install         = $kafka::consumer::service_install,
+  Boolean $service_restart         = $kafka::consumer::service_restart,
+  Hash $config                     = $kafka::consumer::config,
+  Hash $config_defaults            = $kafka::consumer::config_defaults,
 ) {
 
   $consumer_config = deep_merge($config_defaults, $config)
 
-  $config_notify = $service_restart ? {
-    true    => Service[$service_name],
-    default => undef
+  if ($service_install and $service_restart) {
+    $config_notify = Service[$service_name]
+  } else {
+    $config_notify = undef
   }
 
   file { "${config_dir}/consumer.properties":

--- a/manifests/consumer/service.pp
+++ b/manifests/consumer/service.pp
@@ -58,7 +58,7 @@ class kafka::consumer::service(
         ensure => absent,
       }
 
-      File["${service_name}.service"]
+      File["/etc/systemd/system/${service_name}.service"]
       ~> Exec['systemctl-daemon-reload']
       -> Service[$service_name]
 

--- a/manifests/consumer/service.pp
+++ b/manifests/consumer/service.pp
@@ -8,71 +8,76 @@
 # It manages the kafka-consumer service
 #
 class kafka::consumer::service(
-  Hash $env                     = $kafka::consumer::env,
-  $consumer_jmx_opts            = $kafka::consumer::consumer_jmx_opts,
-  $consumer_log4j_opts          = $kafka::consumer::consumer_log4j_opts,
-  $service_config               = $kafka::consumer::service_config,
-  $service_defaults             = $kafka::consumer::service_defaults,
-  $service_requires_zookeeper   = $kafka::consumer::service_requires_zookeeper,
-  $limit_nofile                 = $kafka::consumer::limit_nofile,
-  Stdlib::Absolutepath $bin_dir = $kafka::consumer::bin_dir,
-  String $user                  = $kafka::consumer::user,
-  String $group                 = $kafka::consumer::group,
+  String $user                               = $kafka::consumer::user,
+  String $group                              = $kafka::consumer::group,
+  Stdlib::Absolutepath $config_dir           = $kafka::consumer::config_dir,
+  Stdlib::Absolutepath $log_dir              = $kafka::consumer::log_dir,
+  Stdlib::Absolutepath $bin_dir              = $kafka::consumer::bin_dir,
+  String $service_name                       = $kafka::consumer::service_name,
+  Boolean $service_install                   = $kafka::consumer::service_install,
+  Enum['running', 'stopped'] $service_ensure = $kafka::consumer::service_ensure,
+  Boolean $service_requires_zookeeper        = $kafka::consumer::service_requires_zookeeper,
+  Integer $limit_nofile                      = $kafka::consumer::limit_nofile,
+  Hash $env                                  = $kafka::consumer::env,
+  $consumer_jmx_opts                         = $kafka::consumer::consumer_jmx_opts,
+  $consumer_log4j_opts                       = $kafka::consumer::consumer_log4j_opts,
+  $service_config                            = $kafka::consumer::service_config,
+  $service_defaults                          = $kafka::consumer::service_defaults,
 ) {
 
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  $consumer_service_config = deep_merge($service_defaults, $service_config)
+  if $service_install {
+    $consumer_service_config = deep_merge($service_defaults, $service_config)
 
-  if $consumer_service_config['topic'] == '' {
-    fail('[Consumer] You need to specify a value for topic')
-  }
-  if $consumer_service_config['zookeeper'] == '' {
-    fail('[Consumer] You need to specify a value for zookeeper')
-  }
-
-  $service_name = 'kafka-consumer'
-  $env_defaults = {
-    'KAFKA_JMX_OPTS'   => $consumer_jmx_opts,
-    'KAFKA_LOG4J_OPTS' => $consumer_log4j_opts,
-  }
-  $environment = deep_merge($env_defaults, $env)
-
-  if $::service_provider == 'systemd' {
-    include ::systemd
-
-    file { "${service_name}.service":
-      ensure  => file,
-      path    => "/etc/systemd/system/${service_name}.service",
-      mode    => '0644',
-      content => template('kafka/unit.erb'),
+    if $consumer_service_config['topic'] == '' {
+      fail('[Consumer] You need to specify a value for topic')
+    }
+    if $consumer_service_config['zookeeper'] == '' {
+      fail('[Consumer] You need to specify a value for zookeeper')
     }
 
-    file { "/etc/init.d/${service_name}":
-      ensure => absent,
+    $env_defaults = {
+      'KAFKA_JMX_OPTS'   => $consumer_jmx_opts,
+      'KAFKA_LOG4J_OPTS' => $consumer_log4j_opts,
+    }
+    $environment = deep_merge($env_defaults, $env)
+
+    if $::service_provider == 'systemd' {
+      include ::systemd
+
+      file { "${service_name}.service":
+        ensure  => file,
+        path    => "/etc/systemd/system/${service_name}.service",
+        mode    => '0644',
+        content => template('kafka/unit.erb'),
+      }
+
+      file { "/etc/init.d/${service_name}":
+        ensure => absent,
+      }
+
+      File["${service_name}.service"]
+      ~> Exec['systemctl-daemon-reload']
+      -> Service[$service_name]
+
+    } else {
+      file { "${service_name}.service":
+        ensure  => file,
+        path    => "/etc/init.d/${service_name}",
+        mode    => '0755',
+        content => template('kafka/init.erb'),
+        before  => Service[$service_name],
+      }
     }
 
-    File["${service_name}.service"]
-    ~> Exec['systemctl-daemon-reload']
-    -> Service[$service_name]
-
-  } else {
-
-    file { "${service_name}.service":
-      ensure  => file,
-      path    => "/etc/init.d/${service_name}",
-      mode    => '0755',
-      content => template('kafka/init.erb'),
-      before  => Service[$service_name],
+    service { $service_name:
+      ensure     => $service_ensure,
+      enable     => true,
+      hasstatus  => true,
+      hasrestart => true,
     }
-  }
-
-  service { $service_name:
-    ensure     => running,
-    enable     => true,
-    hasstatus  => true,
-    hasrestart => true,
   }
 }

--- a/manifests/consumer/service.pp
+++ b/manifests/consumer/service.pp
@@ -48,9 +48,8 @@ class kafka::consumer::service(
     if $::service_provider == 'systemd' {
       include ::systemd
 
-      file { "${service_name}.service":
+      file { "/etc/systemd/system/${service_name}.service":
         ensure  => file,
-        path    => "/etc/systemd/system/${service_name}.service",
         mode    => '0644',
         content => template('kafka/unit.erb'),
       }
@@ -64,9 +63,8 @@ class kafka::consumer::service(
       -> Service[$service_name]
 
     } else {
-      file { "${service_name}.service":
+      file { "/etc/init.d/${service_name}":
         ensure  => file,
-        path    => "/etc/init.d/${service_name}",
         mode    => '0755',
         content => template('kafka/init.erb'),
         before  => Service[$service_name],

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -61,6 +61,27 @@
 # [*log_dir*]
 # The directory for kafka log files.
 #
+# [*bin_dir*]
+# The directory where the kafka scripts are.
+#
+# [*service_name*]
+# Set the name of the service.
+#
+# [*service_install*]
+# Install the init.d or systemd service.
+#
+# [*service_ensure*]
+# Set the ensure state of the service to 'stopped' or 'running'.
+#
+# [*service_restart*]
+# Whether the configuration files should trigger a service restart.
+#
+# [*service_requires_zookeeper*]
+# Whether the service should require the ZooKeeper service.
+#
+# [*limit_nofile*]
+# Set the 'LimitNOFILE' option of the systemd service.
+#
 # [*env*]
 # A hash of the environment variables to set.
 #
@@ -82,12 +103,6 @@
 # [*max_heap*]
 # Max heap size passed to java with -Xmx (<size>[g|G|m|M|k|K])
 #
-# [*service_restart*]
-# Boolean, if the configuration files should trigger a service restart
-#
-# [*bin_dir*]
-# The directory where the kafka scripts are
-#
 # === Examples
 #
 # Create the mirror service connecting to a local zookeeper
@@ -97,39 +112,42 @@
 # }
 #
 class kafka::mirror (
-  String $version                       = $kafka::params::version,
-  String $scala_version                 = $kafka::params::scala_version,
-  Stdlib::Absolutepath $install_dir     = $kafka::params::install_dir,
-  Stdlib::HTTPUrl $mirror_url           = $kafka::params::mirror_url,
-  Boolean $install_java                 = $kafka::params::install_java,
-  Stdlib::Absolutepath $package_dir     = $kafka::params::package_dir,
-  Optional[String] $package_name        = $kafka::params::package_name,
-  String $package_ensure                = $kafka::params::package_ensure,
-  String $user                          = $kafka::params::user,
-  String $group                         = $kafka::params::group,
-  Optional[Integer] $user_id            = $kafka::params::user_id,
-  Optional[Integer] $group_id           = $kafka::params::group_id,
-  Boolean $manage_user                  = $kafka::params::manage_user,
-  Boolean $manage_group                 = $kafka::params::manage_group,
-  Stdlib::Absolutepath $config_dir      = $kafka::params::config_dir,
-  Stdlib::Absolutepath $log_dir         = $kafka::params::log_dir,
-  Hash $env                             = {},
-  Hash $consumer_config                 = {},
-  Hash $consumer_config_defaults        = $kafka::params::consumer_config_defaults,
-  Hash $producer_config                 = {},
-  Hash $producer_config_defaults        = $kafka::params::producer_config_defaults,
-  Integer $num_streams                  = $kafka::params::num_streams,
-  Integer $num_producers                = $kafka::params::num_producers,
-  Boolean $abort_on_send_failure        = $kafka::params::abort_on_send_failure,
-  Integer $limit_nofile                 = $kafka::params::limit_nofile,
-  $whitelist                            = $kafka::params::whitelist,
-  $blacklist                            = $kafka::params::blacklist,
-  Pattern[/\d+[g|G|m|M|k|K]/] $max_heap = $kafka::params::mirror_max_heap,
-  Boolean $service_restart              = $kafka::params::service_restart,
-  Boolean $service_requires_zookeeper   = $kafka::params::service_requires_zookeeper,
-  $mirror_jmx_opts                      = $kafka::params::mirror_jmx_opts,
-  $mirror_log4j_opts                    = $kafka::params::mirror_log4j_opts,
-  Stdlib::Absolutepath $bin_dir         = $kafka::params::bin_dir,
+  String $version                            = $kafka::params::version,
+  String $scala_version                      = $kafka::params::scala_version,
+  Stdlib::Absolutepath $install_dir          = $kafka::params::install_dir,
+  Stdlib::HTTPUrl $mirror_url                = $kafka::params::mirror_url,
+  Boolean $install_java                      = $kafka::params::install_java,
+  Stdlib::Absolutepath $package_dir          = $kafka::params::package_dir,
+  Optional[String] $package_name             = $kafka::params::package_name,
+  String $package_ensure                     = $kafka::params::package_ensure,
+  String $user                               = $kafka::params::user,
+  String $group                              = $kafka::params::group,
+  Optional[Integer] $user_id                 = $kafka::params::user_id,
+  Optional[Integer] $group_id                = $kafka::params::group_id,
+  Boolean $manage_user                       = $kafka::params::manage_user,
+  Boolean $manage_group                      = $kafka::params::manage_group,
+  Stdlib::Absolutepath $config_dir           = $kafka::params::config_dir,
+  Stdlib::Absolutepath $log_dir              = $kafka::params::log_dir,
+  Stdlib::Absolutepath $bin_dir              = $kafka::params::bin_dir,
+  String $service_name                       = 'kafka-mirror',
+  Boolean $service_install                   = $kafka::params::service_install,
+  Enum['running', 'stopped'] $service_ensure = $kafka::params::service_ensure,
+  Boolean $service_restart                   = $kafka::params::service_restart,
+  Boolean $service_requires_zookeeper        = $kafka::params::service_requires_zookeeper,
+  Integer $limit_nofile                      = $kafka::params::limit_nofile,
+  Hash $env                                  = {},
+  Hash $consumer_config                      = {},
+  Hash $consumer_config_defaults             = $kafka::params::consumer_config_defaults,
+  Hash $producer_config                      = {},
+  Hash $producer_config_defaults             = $kafka::params::producer_config_defaults,
+  Integer $num_streams                       = $kafka::params::num_streams,
+  Integer $num_producers                     = $kafka::params::num_producers,
+  Boolean $abort_on_send_failure             = $kafka::params::abort_on_send_failure,
+  $whitelist                                 = $kafka::params::whitelist,
+  $blacklist                                 = $kafka::params::blacklist,
+  Pattern[/\d+[g|G|m|M|k|K]/] $max_heap      = $kafka::params::mirror_max_heap,
+  $mirror_jmx_opts                           = $kafka::params::mirror_jmx_opts,
+  $mirror_log4j_opts                         = $kafka::params::mirror_log4j_opts,
 ) inherits kafka::params {
 
   class { '::kafka::mirror::install': }

--- a/manifests/mirror/config.pp
+++ b/manifests/mirror/config.pp
@@ -8,12 +8,14 @@
 # It manages the mirror-maker config files
 #
 class kafka::mirror::config(
-  $consumer_config          = $kafka::mirror::consumer_config,
-  $consumer_config_defaults = $kafka::mirror::consumer_config_defaults,
-  $producer_config          = $kafka::mirror::producer_config,
-  $producer_config_defaults = $kafka::mirror::producer_config_defaults,
-  $service_restart          = $kafka::mirror::service_restart,
-  $config_dir               = $kafka::mirror::config_dir,
+  Stdlib::Absolutepath $config_dir = $kafka::mirror::config_dir,
+  String $service_name             = $kafka::mirror::service_name,
+  Boolean $service_install         = $kafka::mirror::service_install,
+  Boolean $service_restart         = $kafka::mirror::service_restart,
+  Hash $consumer_config            = $kafka::mirror::consumer_config,
+  Hash $consumer_config_defaults   = $kafka::mirror::consumer_config_defaults,
+  Hash $producer_config            = $kafka::mirror::producer_config,
+  Hash $producer_config_defaults   = $kafka::mirror::producer_config_defaults,
 ) {
 
   if $caller_module_name != $module_name {
@@ -38,18 +40,20 @@ class kafka::mirror::config(
   }
 
   class { '::kafka::consumer::config':
+    config_dir      => $config_dir,
+    service_name    => $service_name,
+    service_install => $service_install,
+    service_restart => $service_restart,
     config          => $consumer_config,
     config_defaults => $consumer_config_defaults,
-    service_name    => 'kafka-mirror',
-    service_restart => $service_restart,
-    config_dir      => $config_dir,
   }
 
   class { '::kafka::producer::config':
+    config_dir      => $config_dir,
+    service_name    => $service_name,
+    service_install => $service_install,
+    service_restart => $service_restart,
     config          => $producer_config,
     config_defaults => $producer_config_defaults,
-    service_name    => 'kafka-mirror',
-    service_restart => $service_restart,
-    config_dir      => $config_dir,
   }
 }

--- a/manifests/mirror/service.pp
+++ b/manifests/mirror/service.pp
@@ -8,76 +8,80 @@
 # It manages the kafka-mirror service
 #
 class kafka::mirror::service(
-  $service_requires_zookeeper   = $kafka::mirror::service_requires_zookeeper,
-  Hash $env                     = $kafka::mirror::env,
-  $mirror_jmx_opts              = $kafka::mirror::mirror_jmx_opts,
-  $mirror_log4j_opts            = $kafka::mirror::mirror_log4j_opts,
-  $consumer_config              = $kafka::mirror::consumer_config,
-  $producer_config              = $kafka::mirror::producer_config,
-  $limit_nofile                 = $kafka::mirror::limit_nofile,
-  $num_streams                  = $kafka::mirror::num_streams,
-  $num_producers                = $kafka::mirror::num_producers,
-  $abort_on_send_failure        = $kafka::mirror::abort_on_send_failure,
-  $whitelist                    = $kafka::mirror::whitelist,
-  $blacklist                    = $kafka::mirror::blacklist,
-  $max_heap                     = $kafka::mirror::max_heap,
-  $config_dir                   = $kafka::mirror::config_dir,
-  Stdlib::Absolutepath $bin_dir = $kafka::mirror::bin_dir,
-  String $user                  = $kafka::mirror::user,
-  String $group                 = $kafka::mirror::group,
+  String $user                               = $kafka::mirror::user,
+  String $group                              = $kafka::mirror::group,
+  Stdlib::Absolutepath $config_dir           = $kafka::mirror::config_dir,
+  Stdlib::Absolutepath $log_dir              = $kafka::mirror::log_dir,
+  Stdlib::Absolutepath $bin_dir              = $kafka::mirror::bin_dir,
+  String $service_name                       = $kafka::mirror::service_name,
+  Boolean $service_install                   = $kafka::mirror::service_install,
+  Enum['running', 'stopped'] $service_ensure = $kafka::mirror::service_ensure,
+  Boolean $service_requires_zookeeper        = $kafka::mirror::service_requires_zookeeper,
+  Integer $limit_nofile                      = $kafka::mirror::limit_nofile,
+  Hash $env                                  = $kafka::mirror::env,
+  $mirror_jmx_opts                           = $kafka::mirror::mirror_jmx_opts,
+  $mirror_log4j_opts                         = $kafka::mirror::mirror_log4j_opts,
+  $consumer_config                           = $kafka::mirror::consumer_config,
+  $producer_config                           = $kafka::mirror::producer_config,
+  $num_streams                               = $kafka::mirror::num_streams,
+  $num_producers                             = $kafka::mirror::num_producers,
+  $abort_on_send_failure                     = $kafka::mirror::abort_on_send_failure,
+  $whitelist                                 = $kafka::mirror::whitelist,
+  $blacklist                                 = $kafka::mirror::blacklist,
+  $max_heap                                  = $kafka::mirror::max_heap,
 ) {
 
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  $service_name = 'kafka-mirror'
-  $env_defaults = {
-    'KAFKA_JMX_OPTS'   => $mirror_jmx_opts,
-    'KAFKA_LOG4J_OPTS' => $mirror_log4j_opts,
-    'KAFKA_HEAP_OPTS'  => "-Xmx${max_heap}",
-  }
-  $environment = deep_merge($env_defaults, $env)
+  if $service_install {
+    $env_defaults = {
+      'KAFKA_JMX_OPTS'   => $mirror_jmx_opts,
+      'KAFKA_LOG4J_OPTS' => $mirror_log4j_opts,
+      'KAFKA_HEAP_OPTS'  => "-Xmx${max_heap}",
+    }
+    $environment = deep_merge($env_defaults, $env)
 
-  if versioncmp($kafka::mirror::version, '0.9.0') >= 0 {
-    $abort_on_send_failure_opt = "--abort.on.send.failure=${abort_on_send_failure}"
-  } else {
-    $abort_on_send_failure_opt = ''
-  }
-
-  if $::service_provider == 'systemd' {
-    include ::systemd
-
-    file { "${service_name}.service":
-      ensure  => file,
-      path    => "/etc/systemd/system/${service_name}.service",
-      mode    => '0644',
-      content => template('kafka/unit.erb'),
+    if versioncmp($kafka::mirror::version, '0.9.0') >= 0 {
+      $abort_on_send_failure_opt = "--abort.on.send.failure=${abort_on_send_failure}"
+    } else {
+      $abort_on_send_failure_opt = ''
     }
 
-    file { "/etc/init.d/${service_name}":
-      ensure => absent,
+    if $::service_provider == 'systemd' {
+      include ::systemd
+
+      file { "${service_name}.service":
+        ensure  => file,
+        path    => "/etc/systemd/system/${service_name}.service",
+        mode    => '0644',
+        content => template('kafka/unit.erb'),
+      }
+
+      file { "/etc/init.d/${service_name}":
+        ensure => absent,
+      }
+
+      File["${service_name}.service"]
+      ~> Exec['systemctl-daemon-reload']
+      -> Service[$service_name]
+
+    } else {
+      file { "${service_name}.service":
+        ensure  => file,
+        path    => "/etc/init.d/${service_name}",
+        mode    => '0755',
+        content => template('kafka/init.erb'),
+        before  => Service[$service_name],
+      }
     }
 
-    File["${service_name}.service"]
-    ~> Exec['systemctl-daemon-reload']
-    -> Service[$service_name]
-
-  } else {
-
-    file { "${service_name}.service":
-      ensure  => file,
-      path    => "/etc/init.d/${service_name}",
-      mode    => '0755',
-      content => template('kafka/init.erb'),
-      before  => Service[$service_name],
+    service { $service_name:
+      ensure     => $service_ensure,
+      enable     => true,
+      hasstatus  => true,
+      hasrestart => true,
     }
-  }
-
-  service { $service_name:
-    ensure     => running,
-    enable     => true,
-    hasstatus  => true,
-    hasrestart => true,
   }
 }

--- a/manifests/mirror/service.pp
+++ b/manifests/mirror/service.pp
@@ -62,7 +62,7 @@ class kafka::mirror::service(
         ensure => absent,
       }
 
-      File["${service_name}.service"]
+      File["/etc/systemd/system/${service_name}.service"]
       ~> Exec['systemctl-daemon-reload']
       -> Service[$service_name]
 

--- a/manifests/mirror/service.pp
+++ b/manifests/mirror/service.pp
@@ -52,9 +52,8 @@ class kafka::mirror::service(
     if $::service_provider == 'systemd' {
       include ::systemd
 
-      file { "${service_name}.service":
+      file { "/etc/systemd/system/${service_name}.service":
         ensure  => file,
-        path    => "/etc/systemd/system/${service_name}.service",
         mode    => '0644',
         content => template('kafka/unit.erb'),
       }
@@ -68,9 +67,8 @@ class kafka::mirror::service(
       -> Service[$service_name]
 
     } else {
-      file { "${service_name}.service":
+      file { "/etc/init.d/${service_name}":
         ensure  => file,
-        path    => "/etc/init.d/${service_name}",
         mode    => '0755',
         content => template('kafka/init.erb'),
         before  => Service[$service_name],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,11 +32,11 @@ class kafka::params {
   $manage_user    = true
   $manage_group   = true
 
+  $service_install = true
+  $service_ensure = 'running'
   $service_requires_zookeeper = false
-
-  $broker_service_install = true
-  $broker_service_ensure = 'running'
-
+  $service_restart = true
+  $limit_nofile = 65536
 
   $broker_jmx_opts = '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false \
   -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9990'
@@ -55,10 +55,6 @@ class kafka::params {
   $consumer_jmx_opts   = '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false \
   -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9993'
   $consumer_log4j_opts = $broker_log4j_opts
-
-  $limit_nofile = 65536
-
-  $service_restart = true
 
   #http://kafka.apache.org/documentation.html#brokerconfigs
   $broker_config_defaults = {

--- a/manifests/producer.pp
+++ b/manifests/producer.pp
@@ -61,17 +61,32 @@
 # [*log_dir*]
 # The directory for kafka log files.
 #
+# [*bin_dir*]
+# The directory where the kafka scripts are.
+#
+# [*service_name*]
+# Set the name of the service.
+#
+# [*service_install*]
+# Install the init.d or systemd service.
+#
+# [*service_ensure*]
+# Set the ensure state of the service to 'stopped' or 'running'.
+#
+# [*service_restart*]
+# Whether the configuration files should trigger a service restart.
+#
+# [*service_requires_zookeeper*]
+# Whether the service should require the ZooKeeper service.
+#
+# [*limit_nofile*]
+# Set the 'LimitNOFILE' option of the systemd service.
+#
 # [*env*]
 # A hash of the environment variables to set.
 #
 # [*config*]
 # A hash of the producer configuration options.
-#
-# [*service_restart*]
-# Boolean, if the configuration files should trigger a service restart
-#
-# [*bin_dir*]
-# The directory where the kafka scripts are
 #
 # === Examples
 #
@@ -83,32 +98,36 @@
 #
 class kafka::producer (
   $input,
-  String $version                     = $kafka::params::version,
-  String $scala_version               = $kafka::params::scala_version,
-  Stdlib::Absolutepath $install_dir   = $kafka::params::install_dir,
-  Stdlib::HTTPUrl $mirror_url         = $kafka::params::mirror_url,
-  Boolean $install_java               = $kafka::params::install_java,
-  Stdlib::Absolutepath $package_dir   = $kafka::params::package_dir,
-  Optional[String] $package_name      = $kafka::params::package_name,
-  String $package_ensure              = $kafka::params::package_ensure,
-  String $user                        = $kafka::params::user,
-  String $group                       = $kafka::params::group,
-  Optional[Integer] $user_id          = $kafka::params::user_id,
-  Optional[Integer] $group_id         = $kafka::params::group_id,
-  Boolean $manage_user                = $kafka::params::manage_user,
-  Boolean $manage_group               = $kafka::params::manage_group,
-  Stdlib::Absolutepath $config_dir    = $kafka::params::config_dir,
-  Stdlib::Absolutepath $log_dir       = $kafka::params::log_dir,
-  Hash $env                           = {},
-  Hash $config                        = {},
-  Hash $config_defaults               = $kafka::params::producer_config_defaults,
-  Hash $service_config                = {},
-  Hash $service_defaults              = $kafka::params::producer_service_defaults,
-  Boolean $service_restart            = $kafka::params::service_restart,
-  Boolean $service_requires_zookeeper = $kafka::params::service_requires_zookeeper,
-  $producer_jmx_opts                  = $kafka::params::producer_jmx_opts,
-  $producer_log4j_opts                = $kafka::params::producer_log4j_opts,
-  Stdlib::Absolutepath $bin_dir       = $kafka::params::bin_dir,
+  String $version                            = $kafka::params::version,
+  String $scala_version                      = $kafka::params::scala_version,
+  Stdlib::Absolutepath $install_dir          = $kafka::params::install_dir,
+  Stdlib::HTTPUrl $mirror_url                = $kafka::params::mirror_url,
+  Boolean $install_java                      = $kafka::params::install_java,
+  Stdlib::Absolutepath $package_dir          = $kafka::params::package_dir,
+  Optional[String] $package_name             = $kafka::params::package_name,
+  String $package_ensure                     = $kafka::params::package_ensure,
+  String $user                               = $kafka::params::user,
+  String $group                              = $kafka::params::group,
+  Optional[Integer] $user_id                 = $kafka::params::user_id,
+  Optional[Integer] $group_id                = $kafka::params::group_id,
+  Boolean $manage_user                       = $kafka::params::manage_user,
+  Boolean $manage_group                      = $kafka::params::manage_group,
+  Stdlib::Absolutepath $config_dir           = $kafka::params::config_dir,
+  Stdlib::Absolutepath $log_dir              = $kafka::params::log_dir,
+  Stdlib::Absolutepath $bin_dir              = $kafka::params::bin_dir,
+  String $service_name                       = 'kafka-producer',
+  Boolean $service_install                   = $kafka::params::service_install,
+  Enum['running', 'stopped'] $service_ensure = $kafka::params::service_ensure,
+  Boolean $service_restart                   = $kafka::params::service_restart,
+  Boolean $service_requires_zookeeper        = $kafka::params::service_requires_zookeeper,
+  Integer $limit_nofile                      = $kafka::params::limit_nofile,
+  Hash $env                                  = {},
+  Hash $config                               = {},
+  Hash $config_defaults                      = $kafka::params::producer_config_defaults,
+  Hash $service_config                       = {},
+  Hash $service_defaults                     = $kafka::params::producer_service_defaults,
+  $producer_jmx_opts                         = $kafka::params::producer_jmx_opts,
+  $producer_log4j_opts                       = $kafka::params::producer_log4j_opts,
 ) inherits kafka::params {
 
   class { '::kafka::producer::install': }

--- a/manifests/producer/config.pp
+++ b/manifests/producer/config.pp
@@ -8,18 +8,20 @@
 # It manages the producer config files
 #
 class kafka::producer::config(
-  $config          = $kafka::producer::config,
-  $config_defaults = $kafka::producer::config_defaults,
-  $service_name    = 'kafka-producer',
-  $service_restart = $kafka::producer::service_restart,
-  $config_dir      = $kafka::producer::config_dir,
+  Stdlib::Absolutepath $config_dir = $kafka::producer::config_dir,
+  String $service_name             = $kafka::producer::service_name,
+  Boolean $service_install         = $kafka::producer::service_install,
+  Boolean $service_restart         = $kafka::producer::service_restart,
+  Hash $config                     = $kafka::producer::config,
+  Hash $config_defaults            = $kafka::producer::config_defaults,
 ) {
 
   $producer_config = deep_merge($config_defaults, $config)
 
-  $config_notify = $service_restart ? {
-    true    => Service[$service_name],
-    default => undef
+  if ($service_install and $service_restart) {
+    $config_notify = Service[$service_name]
+  } else {
+    $config_notify = undef
   }
 
   file { "${config_dir}/producer.properties":

--- a/manifests/producer/service.pp
+++ b/manifests/producer/service.pp
@@ -49,9 +49,8 @@ class kafka::producer::service(
     if $::service_provider == 'systemd' {
       fail('Console Producer is not supported on systemd, because the stdin of the process cannot be redirected')
     } else {
-      file { "${service_name}.service":
+      file { "/etc/init.d/${service_name}":
         ensure  => file,
-        path    => "/etc/init.d/${service_name}",
         mode    => '0755',
         content => template('kafka/init.erb'),
         before  => Service[$service_name],

--- a/manifests/producer/service.pp
+++ b/manifests/producer/service.pp
@@ -8,53 +8,61 @@
 # It manages the kafka-producer service
 #
 class kafka::producer::service(
-  $input                        = $kafka::producer::input,
-  Hash $env                     = $kafka::producer::env,
-  $producer_jmx_opts            = $kafka::producer::producer_jmx_opts,
-  $producer_log4j_opts          = $kafka::producer::producer_log4j_opts,
-  $service_config               = $kafka::producer::service_config,
-  $service_defaults             = $kafka::producer::service_defaults,
-  $service_requires_zookeeper   = $kafka::producer::service_requires_zookeeper,
-  Stdlib::Absolutepath $bin_dir = $kafka::producer::bin_dir,
-  String $user                  = $kafka::producer::user,
-  String $group                 = $kafka::producer::group,
+  String $user                               = $kafka::producer::user,
+  String $group                              = $kafka::producer::group,
+  Stdlib::Absolutepath $config_dir           = $kafka::producer::config_dir,
+  Stdlib::Absolutepath $log_dir              = $kafka::producer::log_dir,
+  Stdlib::Absolutepath $bin_dir              = $kafka::producer::bin_dir,
+  String $service_name                       = $kafka::producer::service_name,
+  Boolean $service_install                   = $kafka::producer::service_install,
+  Enum['running', 'stopped'] $service_ensure = $kafka::producer::service_ensure,
+  Boolean $service_requires_zookeeper        = $kafka::producer::service_requires_zookeeper,
+  Integer $limit_nofile                      = $kafka::producer::limit_nofile,
+  Hash $env                                  = $kafka::producer::env,
+  $input                                     = $kafka::producer::input,
+  $producer_jmx_opts                         = $kafka::producer::producer_jmx_opts,
+  $producer_log4j_opts                       = $kafka::producer::producer_log4j_opts,
+  $service_config                            = $kafka::producer::service_config,
+  $service_defaults                          = $kafka::producer::service_defaults,
 ) {
 
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  $producer_service_config = deep_merge($service_defaults, $service_config)
+  if $service_install {
+    $producer_service_config = deep_merge($service_defaults, $service_config)
 
-  if $producer_service_config['broker-list'] == '' {
-    fail('[Producer] You need to specify a value for broker-list')
-  }
-  if $producer_service_config['topic'] == '' {
-    fail('[Producer] You need to specify a value for topic')
-  }
+    if $producer_service_config['broker-list'] == '' {
+      fail('[Producer] You need to specify a value for broker-list')
+    }
+    if $producer_service_config['topic'] == '' {
+      fail('[Producer] You need to specify a value for topic')
+    }
 
-  if $::service_provider == 'systemd' {
-    fail('Console Producer is not supported on systemd, because the stdin of the process cannot be redirected')
-  }
+    $env_defaults = {
+      'KAFKA_JMX_OPTS'   => $producer_jmx_opts,
+      'KAFKA_LOG4J_OPTS' => $producer_log4j_opts,
+    }
+    $environment = deep_merge($env_defaults, $env)
 
-  $service_name = 'kafka-producer'
-  $env_defaults = {
-    'KAFKA_JMX_OPTS'   => $producer_jmx_opts,
-    'KAFKA_LOG4J_OPTS' => $producer_log4j_opts,
-  }
-  $environment = deep_merge($env_defaults, $env)
+    if $::service_provider == 'systemd' {
+      fail('Console Producer is not supported on systemd, because the stdin of the process cannot be redirected')
+    } else {
+      file { "${service_name}.service":
+        ensure  => file,
+        path    => "/etc/init.d/${service_name}",
+        mode    => '0755',
+        content => template('kafka/init.erb'),
+        before  => Service[$service_name],
+      }
+    }
 
-  file { "/etc/init.d/${service_name}":
-    ensure  => file,
-    mode    => '0755',
-    content => template('kafka/init.erb'),
-    before  => Service[$service_name],
-  }
-
-  service { $service_name:
-    ensure     => running,
-    enable     => true,
-    hasstatus  => true,
-    hasrestart => true,
+    service { $service_name:
+      ensure     => $service_ensure,
+      enable     => true,
+      hasstatus  => true,
+      hasrestart => true,
+    }
   }
 }

--- a/spec/classes/broker_spec.rb
+++ b/spec/classes/broker_spec.rb
@@ -49,12 +49,12 @@ describe 'kafka::broker', type: :class do
           common_params.merge(service_install: false)
         end
 
-        it { is_expected.not_to contain_file('kafka.service') }
+        it { is_expected.not_to contain_file('/etc/init.d/kafka') }
 
         it { is_expected.not_to contain_service('kafka') }
       end
       context 'defaults' do
-        it { is_expected.to contain_file('kafka.service') }
+        it { is_expected.to contain_file('/etc/init.d/kafka') }
 
         it { is_expected.to contain_service('kafka') }
       end
@@ -93,15 +93,15 @@ describe 'kafka::broker', type: :class do
           common_params.merge(service_install: false)
         end
 
-        it { is_expected.not_to contain_file('kafka.service') }
+        it { is_expected.not_to contain_file('/etc/systemd/system/kafka.service') }
 
         it { is_expected.not_to contain_service('kafka') }
       end
 
       context 'defaults' do
-        it { is_expected.to contain_file('kafka.service').that_notifies('Exec[systemctl-daemon-reload]') }
+        it { is_expected.to contain_file('/etc/systemd/system/kafka.service').that_notifies('Exec[systemctl-daemon-reload]') }
 
-        it { is_expected.to contain_file('kafka.service').with_content %r{^LimitNOFILE=65536$} }
+        it { is_expected.to contain_file('/etc/systemd/system/kafka.service').with_content %r{^LimitNOFILE=65536$} }
 
         it do
           is_expected.to contain_file('/etc/init.d/kafka').with(
@@ -121,7 +121,7 @@ describe 'kafka::broker', type: :class do
           }
         end
 
-        it { is_expected.not_to contain_file('kafka.service').with_content %r{^Requires=zookeeper.service$} }
+        it { is_expected.not_to contain_file('/etc/systemd/system/kafka.service').with_content %r{^Requires=zookeeper.service$} }
       end
 
       context 'service_requires_zookeeper enabled' do
@@ -131,7 +131,7 @@ describe 'kafka::broker', type: :class do
           }
         end
 
-        it { is_expected.to contain_file('kafka.service').with_content %r{^Requires=zookeeper.service$} }
+        it { is_expected.to contain_file('/etc/systemd/system/kafka.service').with_content %r{^Requires=zookeeper.service$} }
       end
     end
   end

--- a/spec/classes/consumer_spec.rb
+++ b/spec/classes/consumer_spec.rb
@@ -40,7 +40,7 @@ describe 'kafka::consumer', type: :class do
 
     describe 'kafka::consumer::service' do
       context 'defaults' do
-        it { is_expected.to contain_file('kafka-consumer.service') }
+        it { is_expected.to contain_file('/etc/init.d/kafka-consumer') }
 
         it { is_expected.to contain_service('kafka-consumer') }
       end
@@ -69,9 +69,9 @@ describe 'kafka::consumer', type: :class do
 
     describe 'kafka::consumer::service' do
       context 'defaults' do
-        it { is_expected.to contain_file('kafka-consumer.service').that_notifies('Exec[systemctl-daemon-reload]') }
+        it { is_expected.to contain_file('/etc/systemd/system/kafka-consumer.service').that_notifies('Exec[systemctl-daemon-reload]') }
 
-        it { is_expected.to contain_file('kafka-consumer.service').with_content %r{^LimitNOFILE=65536$} }
+        it { is_expected.to contain_file('/etc/systemd/system/kafka-consumer.service').with_content %r{^LimitNOFILE=65536$} }
 
         it do
           is_expected.to contain_file('/etc/init.d/kafka-consumer').with(
@@ -89,7 +89,7 @@ describe 'kafka::consumer', type: :class do
           common_params.merge(service_requires_zookeeper: false)
         end
 
-        it { is_expected.not_to contain_file('kafka-consumer.service').with_content %r{^Requires=zookeeper.service$} }
+        it { is_expected.not_to contain_file('/etc/systemd/system/kafka-consumer.service').with_content %r{^Requires=zookeeper.service$} }
       end
 
       context 'service_requires_zookeeper enabled' do
@@ -97,7 +97,7 @@ describe 'kafka::consumer', type: :class do
           common_params.merge(service_requires_zookeeper: true)
         end
 
-        it { is_expected.to contain_file('kafka-consumer.service').with_content %r{^Requires=zookeeper.service$} }
+        it { is_expected.to contain_file('/etc/systemd/system/kafka-consumer.service').with_content %r{^Requires=zookeeper.service$} }
       end
     end
   end

--- a/spec/classes/mirror_spec.rb
+++ b/spec/classes/mirror_spec.rb
@@ -50,7 +50,7 @@ describe 'kafka::mirror', type: :class do
 
     describe 'kafka::mirror::service' do
       context 'defaults' do
-        it { is_expected.to contain_file('kafka-mirror.service') }
+        it { is_expected.to contain_file('/etc/init.d/kafka-mirror') }
 
         it { is_expected.to contain_service('kafka-mirror') }
       end
@@ -85,9 +85,9 @@ describe 'kafka::mirror', type: :class do
 
     describe 'kafka::mirror::service' do
       context 'defaults' do
-        it { is_expected.to contain_file('kafka-mirror.service').that_notifies('Exec[systemctl-daemon-reload]') }
+        it { is_expected.to contain_file('/etc/systemd/system/kafka-mirror.service').that_notifies('Exec[systemctl-daemon-reload]') }
 
-        it { is_expected.to contain_file('kafka-mirror.service').with_content %r{^LimitNOFILE=65536$} }
+        it { is_expected.to contain_file('/etc/systemd/system/kafka-mirror.service').with_content %r{^LimitNOFILE=65536$} }
 
         it do
           is_expected.to contain_file('/etc/init.d/kafka-mirror').with(
@@ -105,7 +105,7 @@ describe 'kafka::mirror', type: :class do
           common_params.merge(service_requires_zookeeper: false)
         end
 
-        it { is_expected.not_to contain_file('kafka-mirror.service').with_content %r{^Requires=zookeeper.service$} }
+        it { is_expected.not_to contain_file('/etc/systemd/system/kafka-mirror.service').with_content %r{^Requires=zookeeper.service$} }
       end
 
       context 'service_requires_zookeeper enabled' do
@@ -113,7 +113,7 @@ describe 'kafka::mirror', type: :class do
           common_params.merge(service_requires_zookeeper: true)
         end
 
-        it { is_expected.to contain_file('kafka-mirror.service').with_content %r{^Requires=zookeeper.service$} }
+        it { is_expected.to contain_file('/etc/systemd/system/kafka-mirror.service').with_content %r{^Requires=zookeeper.service$} }
       end
     end
   end

--- a/spec/classes/mirror_spec.rb
+++ b/spec/classes/mirror_spec.rb
@@ -44,6 +44,7 @@ describe 'kafka::mirror', type: :class do
 
     describe 'kafka::mirror::config' do
       context 'defaults' do
+        it { is_expected.to contain_class('kafka::consumer::config') }
         it { is_expected.to contain_class('kafka::producer::config') }
       end
     end
@@ -79,6 +80,7 @@ describe 'kafka::mirror', type: :class do
 
     describe 'kafka::mirror::config' do
       context 'defaults' do
+        it { is_expected.to contain_class('kafka::consumer::config') }
         it { is_expected.to contain_class('kafka::producer::config') }
       end
     end


### PR DESCRIPTION
kafka::{broker,consumer,mirror,producer}:
 - made sure all the service related parameters are present (in order) and documented

kafka::{broker,consumer,mirror,producer}::config:
 - made sure all the service related parameters are handled consistently
 - added some missing types

kafka::{broker,consumer,mirror,producer}::service:
 - made sure all the service related parameters are handled consistently
 - added some missing types

This fixes https://github.com/voxpupuli/puppet-kafka/issues/192.