### PR TITLE
MirrorMaker service needed path to .properties files

### DIFF
--- a/spec/classes/consumer_spec.rb
+++ b/spec/classes/consumer_spec.rb
@@ -102,5 +102,6 @@ describe 'kafka::consumer', type: :class do
     end
   end
 
+  it { is_expected.to contain_file('/opt/kafka/config/consumer.properties') }
   it_validates_parameter 'mirror_url'
 end

--- a/spec/classes/mirror_spec.rb
+++ b/spec/classes/mirror_spec.rb
@@ -52,6 +52,7 @@ describe 'kafka::mirror', type: :class do
     describe 'kafka::mirror::service' do
       context 'defaults' do
         it { is_expected.to contain_file('/etc/init.d/kafka-mirror') }
+        it { is_expected.to contain_file('/etc/init.d/kafka-mirror').with_content %r{/opt/kafka/config/(?=.*consumer)|(?=.*producer).properties} }
 
         it { is_expected.to contain_service('kafka-mirror') }
       end
@@ -88,8 +89,8 @@ describe 'kafka::mirror', type: :class do
     describe 'kafka::mirror::service' do
       context 'defaults' do
         it { is_expected.to contain_file('/etc/systemd/system/kafka-mirror.service').that_notifies('Exec[systemctl-daemon-reload]') }
-
         it { is_expected.to contain_file('/etc/systemd/system/kafka-mirror.service').with_content %r{^LimitNOFILE=65536$} }
+        it { is_expected.to contain_file('/etc/systemd/system/kafka-mirror.service').with_content %r{/opt/kafka/config/(?=.*consumer)|(?=.*producer).properties} }
 
         it do
           is_expected.to contain_file('/etc/init.d/kafka-mirror').with(

--- a/templates/init.erb
+++ b/templates/init.erb
@@ -45,7 +45,7 @@ DAEMON_OPTS="<% @consumer_service_config.sort.each do |k,v| -%><% unless v.to_s.
 PGREP_PATTERN=kafka.tools.MirrorMaker
 
 DAEMON="<%= @bin_dir %>/kafka-run-class.sh"
-DAEMON_OPTS="kafka.tools.MirrorMaker --consumer.config <%= @consumer_config -%> --num.streams <%= @num_streams -%> --producer.config <%= @producer_config -%><%- if (scope.function_versioncmp([scope.lookupvar('kafka::version'), '0.9.0.0']) < 0) -%> --num.producers <%= @num_producers -%><%- end -%><%- if !@whitelist.eql?('') -%> --whitelist='<%= @whitelist -%>'<%- end %><%- if !@blacklist.eql?('') -%> --blacklist='<%= @blacklist -%>'<%- end -%> <%= @abort_on_send_failure_opt %>"
+DAEMON_OPTS="kafka.tools.MirrorMaker --consumer.config <%= @config_dir %>/consumer.properties --num.streams <%= @num_streams -%> --producer.config <%= @config_dir %>/producer.properties<%- if (scope.function_versioncmp([scope.lookupvar('kafka::version'), '0.9.0.0']) < 0) -%> --num.producers <%= @num_producers -%><%- end -%><%- if !@whitelist.eql?('') -%> --whitelist='<%= @whitelist -%>'<%- end %><%- if !@blacklist.eql?('') -%> --blacklist='<%= @blacklist -%>'<%- end -%> <%= @abort_on_send_failure_opt %>"
 <%- when 'kafka-producer' -%>
 PGREP_PATTERN=kafka.tools.ConsoleProducer
 

--- a/templates/unit.erb
+++ b/templates/unit.erb
@@ -25,7 +25,7 @@ ExecStart=<%= @bin_dir %>/kafka-server-start.sh <%= @config_dir %>/server.proper
   <%- when 'kafka-consumer' -%>
 ExecStart=<%= @bin_dir %>/kafka-console-consumer.sh <% @consumer_service_config.sort.each do |k,v| -%><% unless v.to_s.strip.empty? -%>--<%= k -%>=<%= v.is_a?(Array) ? v.join(',') : v %> <% end -%><% end -%>
   <%- when 'kafka-mirror' -%>
-ExecStart=<%= @bin_dir %>/kafka-run-class.sh kafka.tools.MirrorMaker --consumer.config <%= @consumer_config -%> --num.streams <%= @num_streams -%> --producer.config <%= @producer_config -%><%- if (scope.function_versioncmp([scope.lookupvar('kafka::version'), '0.9.0.0']) < 0) -%> --num.producers <%= @num_producers -%><%- end -%><%- if !@whitelist.eql?('') -%> --whitelist='<%= @whitelist -%>'<%- end %><%- if !@blacklist.eql?('') -%> --blacklist='<%= @blacklist -%>'<%- end -%> <%= @abort_on_send_failure_opt %>
+ExecStart=<%= @bin_dir %>/kafka-run-class.sh kafka.tools.MirrorMaker --consumer.config <%= @config_dir %>/consumer.properties --num.streams <%= @num_streams -%> --producer.config <%= @config_dir %>/producer.properties<%- if (scope.function_versioncmp([scope.lookupvar('kafka::version'), '0.9.0.0']) < 0) -%> --num.producers <%= @num_producers -%><%- end -%><%- if !@whitelist.eql?('') -%> --whitelist='<%= @whitelist -%>'<%- end %><%- if !@blacklist.eql?('') -%> --blacklist='<%= @blacklist -%>'<%- end -%> <%= @abort_on_send_failure_opt %>
   <%- when 'kafka-producer' -%>
 ExecStart=<%= @bin_dir %>/kafka-console-producer.sh <% @producer_service_config.sort.each do |k,v| -%><% unless v.to_s.strip.empty? -%>--<%= k -%>=<%= v.is_a?(Array) ? v.join(',') : v %> <% end -%><% end -%> <%= @input %>
 <%- end %>


### PR DESCRIPTION
Commit: 6b509b4d1373fd5c1196d6c1f350fb71f248169e changed the behaviour of the service scripts for mirror maker in such a way that they were including the config hash instead of pointing to the file containing the config.
