### PR TITLE
Higher allowed version for module java and lower for zookeeper

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 1.0.0 <= 2.0.0"
+      "version_requirement": ">= 1.0.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/java",
-      "version_requirement": ">= 1.4.2 <= 2.1.0"
+      "version_requirement": ">= 1.4.2 < 3.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "version_requirement": ">= 1.0.0 <= 2.0.0"
     },
     {
       "name": "puppetlabs/java",
-      "version_requirement": ">= 1.4.2 < 2.0.0"
+      "version_requirement": ">= 1.4.2 <= 2.1.0"
     },
     {
       "name": "puppetlabs/stdlib",
@@ -22,7 +22,7 @@
     },
     {
       "name": "deric/zookeeper",
-      "version_requirement": ">= 0.5.1 < 2.0.0"
+      "version_requirement": ">= 0.5.1 < 1.0.0"
     },
     {
       "name": "camptocamp/systemd",


### PR DESCRIPTION
Tested with java module 2.1.0 and fine.
Downed zookeeper module from < 2.0 to < 1.0 to counter for sudden surprises (v0.7.5 is most current atm).


<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
