### PR TITLE
removed the (undocumented) hard-coded defaults for limit_nofile and limit_core

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,8 +38,8 @@ class kafka::params {
   $service_ensure = 'running'
   $service_requires_zookeeper = false
   $service_restart = true
-  $limit_nofile = '65536'
-  $limit_core = 'infinity'
+  $limit_nofile = undef
+  $limit_core = undef
   $timeout_stop = undef
   $exec_stop = false
   $daemon_start = false

--- a/spec/classes/broker_spec.rb
+++ b/spec/classes/broker_spec.rb
@@ -100,8 +100,8 @@ describe 'kafka::broker', type: :class do
 
       context 'defaults' do
         it { is_expected.to contain_file('/etc/systemd/system/kafka.service').that_notifies('Exec[systemctl-daemon-reload]') }
-
-        it { is_expected.to contain_file('/etc/systemd/system/kafka.service').with_content %r{^LimitNOFILE=65536$} }
+        it { is_expected.not_to contain_file('/etc/systemd/system/kafka.service').with_content %r{^LimitNOFILE=} }
+        it { is_expected.not_to contain_file('/etc/systemd/system/kafka.service').with_content %r{^LimitCORE=} }
 
         it do
           is_expected.to contain_file('/etc/init.d/kafka').with(
@@ -112,6 +112,26 @@ describe 'kafka::broker', type: :class do
         it { is_expected.to contain_exec('systemctl-daemon-reload').that_comes_before('Service[kafka]') }
 
         it { is_expected.to contain_service('kafka') }
+      end
+
+      context 'limit_nofile set' do
+        let :params do
+          {
+            limit_nofile: '65536'
+          }
+        end
+
+        it { is_expected.to contain_file('/etc/systemd/system/kafka.service').with_content %r{^LimitNOFILE=65536$} }
+      end
+
+      context 'limit_core set' do
+        let :params do
+          {
+            limit_core: 'infinity'
+          }
+        end
+
+        it { is_expected.to contain_file('/etc/systemd/system/kafka.service').with_content %r{^LimitCORE=infinity$} }
       end
 
       context 'service_requires_zookeeper disabled' do

--- a/spec/classes/consumer_spec.rb
+++ b/spec/classes/consumer_spec.rb
@@ -71,8 +71,6 @@ describe 'kafka::consumer', type: :class do
       context 'defaults' do
         it { is_expected.to contain_file('/etc/systemd/system/kafka-consumer.service').that_notifies('Exec[systemctl-daemon-reload]') }
 
-        it { is_expected.to contain_file('/etc/systemd/system/kafka-consumer.service').with_content %r{^LimitNOFILE=65536$} }
-
         it do
           is_expected.to contain_file('/etc/init.d/kafka-consumer').with(
             ensure: 'absent'

--- a/spec/classes/mirror_spec.rb
+++ b/spec/classes/mirror_spec.rb
@@ -88,7 +88,6 @@ describe 'kafka::mirror', type: :class do
     describe 'kafka::mirror::service' do
       context 'defaults' do
         it { is_expected.to contain_file('/etc/systemd/system/kafka-mirror.service').that_notifies('Exec[systemctl-daemon-reload]') }
-        it { is_expected.to contain_file('/etc/systemd/system/kafka-mirror.service').with_content %r{^LimitNOFILE=65536$} }
         it { is_expected.to contain_file('/etc/systemd/system/kafka-mirror.service').with_content %r{/opt/kafka/config/(?=.*consumer)|(?=.*producer).properties} }
 
         it do


### PR DESCRIPTION
This fixes https://github.com/voxpupuli/puppet-kafka/issues/232.