### PR TITLE
Pin Kafka config directory mode

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,6 +119,7 @@ class kafka (
     ensure => directory,
     owner  => 'root',
     group  => 'root',
+    mode   => '0755',
   }
 
   file { $log_dir:


### PR DESCRIPTION
In some RPM packages, the Kafka config directory may not be world
readable, so Puppet should manage the permissions of both the config directory and items within. 

Let me know if you would like a specific acceptance test added for this, but I don't see file modes referenced anywhere within the existing tests.