### PR TITLE
Add options for more sensible config permissions; puppet stdlib to 4.22.0

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -55,6 +55,9 @@
 # [*manage_group*]
 # Create the kafka group if it's not already present.
 #
+# [*config_mode*]
+# The permissions for the config files.
+#
 # [*config_dir*]
 # The directory to create the kafka config files to.
 #
@@ -123,6 +126,7 @@ class kafka::broker (
   Optional[Integer] $group_id                = $kafka::params::group_id,
   Boolean $manage_user                       = $kafka::params::manage_user,
   Boolean $manage_group                      = $kafka::params::manage_group,
+  Stdlib::Filemode $config_mode              = $kafka::params::config_mode,
   Stdlib::Absolutepath $config_dir           = $kafka::params::config_dir,
   Stdlib::Absolutepath $log_dir              = $kafka::params::log_dir,
   Stdlib::Absolutepath $bin_dir              = $kafka::params::bin_dir,

--- a/manifests/broker/config.pp
+++ b/manifests/broker/config.pp
@@ -13,6 +13,8 @@ class kafka::broker::config(
   Boolean $service_install         = $kafka::broker::service_install,
   Boolean $service_restart         = $kafka::broker::service_restart,
   Hash $config                     = $kafka::broker::config,
+  Stdlib::Filemode $config_mode    = $kafka::broker::config_mode,
+  String $group                    = $kafka::broker::group,
 ) {
 
   if ($caller_module_name != $module_name) {
@@ -29,8 +31,8 @@ class kafka::broker::config(
   file { "${config_dir}/server.properties":
     ensure  => present,
     owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
+    group   => $group,
+    mode    => $config_mode,
     content => template('kafka/properties.erb'),
     notify  => $config_notify,
     require => File[$config_dir],

--- a/manifests/consumer.pp
+++ b/manifests/consumer.pp
@@ -55,6 +55,9 @@
 # [*manage_group*]
 # Create the kafka group if it's not already present.
 #
+# [*config_mode*]
+# The permissions for the config files.
+#
 # [*config_dir*]
 # The directory to create the kafka config files to.
 #
@@ -116,6 +119,7 @@ class kafka::consumer (
   Optional[Integer] $group_id                = $kafka::params::group_id,
   Boolean $manage_user                       = $kafka::params::manage_user,
   Boolean $manage_group                      = $kafka::params::manage_group,
+  Stdlib::Filemode $config_mode              = $kafka::params::config_mode,
   Stdlib::Absolutepath $config_dir           = $kafka::params::config_dir,
   Stdlib::Absolutepath $log_dir              = $kafka::params::log_dir,
   Stdlib::Absolutepath $bin_dir              = $kafka::params::bin_dir,

--- a/manifests/consumer/config.pp
+++ b/manifests/consumer/config.pp
@@ -13,6 +13,8 @@ class kafka::consumer::config(
   Boolean $service_install         = $kafka::consumer::service_install,
   Boolean $service_restart         = $kafka::consumer::service_restart,
   Hash $config                     = $kafka::consumer::config,
+  Stdlib::Filemode $config_mode    = $kafka::consumer::config_mode,
+  String $group                    = $kafka::consumer::group,
 ) {
 
   if ($service_install and $service_restart) {
@@ -25,8 +27,8 @@ class kafka::consumer::config(
   file { "${config_dir}/consumer.properties":
     ensure  => present,
     owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
+    group   => $group,
+    mode    => $config_mode,
     content => template('kafka/properties.erb'),
     notify  => $config_notify,
     require => File[$config_dir],

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -120,6 +120,7 @@ class kafka::mirror (
   Optional[Integer] $group_id                = $kafka::params::group_id,
   Boolean $manage_user                       = $kafka::params::manage_user,
   Boolean $manage_group                      = $kafka::params::manage_group,
+  Stdlib::Filemode $config_mode              = $kafka::params::config_mode,
   Stdlib::Absolutepath $config_dir           = $kafka::params::config_dir,
   Stdlib::Absolutepath $log_dir              = $kafka::params::log_dir,
   Stdlib::Absolutepath $bin_dir              = $kafka::params::bin_dir,

--- a/manifests/mirror/config.pp
+++ b/manifests/mirror/config.pp
@@ -14,6 +14,8 @@ class kafka::mirror::config(
   Boolean $service_restart         = $kafka::mirror::service_restart,
   Hash $consumer_config            = $kafka::mirror::consumer_config,
   Hash $producer_config            = $kafka::mirror::producer_config,
+  Stdlib::Filemode $config_mode    = $kafka::mirror::config_mode,
+  String $group                    = $kafka::mirror::group,
 ) {
 
   if $caller_module_name != $module_name {
@@ -32,17 +34,21 @@ class kafka::mirror::config(
 
   class { '::kafka::consumer::config':
     config_dir      => $config_dir,
+    config_mode     => $config_mode,
     service_name    => $service_name,
     service_install => $service_install,
     service_restart => $service_restart,
     config          => $consumer_config,
+    group           => $group,
   }
 
   class { '::kafka::producer::config':
     config_dir      => $config_dir,
+    config_mode     => $config_mode,
     service_name    => $service_name,
     service_install => $service_install,
     service_restart => $service_restart,
     config          => $producer_config,
+    group           => $group,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,7 @@ class kafka::params {
   $system_group   = false
   $manage_user    = true
   $manage_group   = true
+  $config_mode    = '0644'
 
   $service_install = true
   $service_ensure = 'running'

--- a/manifests/producer.pp
+++ b/manifests/producer.pp
@@ -55,6 +55,9 @@
 # [*manage_group*]
 # Create the kafka group if it's not already present.
 #
+# [*config_mode*]
+# The permissions for the config files.
+#
 # [*config_dir*]
 # The directory to create the kafka config files to.
 #
@@ -118,6 +121,7 @@ class kafka::producer (
   Optional[Integer] $group_id                = $kafka::params::group_id,
   Boolean $manage_user                       = $kafka::params::manage_user,
   Boolean $manage_group                      = $kafka::params::manage_group,
+  Stdlib::Filemode $config_mode              = $kafka::params::config_mode,
   Stdlib::Absolutepath $config_dir           = $kafka::params::config_dir,
   Stdlib::Absolutepath $log_dir              = $kafka::params::log_dir,
   Stdlib::Absolutepath $bin_dir              = $kafka::params::bin_dir,

--- a/manifests/producer/config.pp
+++ b/manifests/producer/config.pp
@@ -13,6 +13,8 @@ class kafka::producer::config(
   Boolean $service_install         = $kafka::producer::service_install,
   Boolean $service_restart         = $kafka::producer::service_restart,
   Hash $config                     = $kafka::producer::config,
+  Stdlib::Filemode $config_mode    = $kafka::producer::config_mode,
+  String $group                    = $kafka::producer::group,
 ) {
 
   if ($service_install and $service_restart) {
@@ -25,8 +27,8 @@ class kafka::producer::config(
   file { "${config_dir}/producer.properties":
     ensure  => present,
     owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
+    group   => $group,
+    mode    => $config_mode,
     content => template('kafka/properties.erb'),
     notify  => $config_notify,
     require => File[$config_dir],

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.22.0 < 5.0.0"
     },
     {
       "name": "deric/zookeeper",


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This adds a `config_mode` option to be able to configure the permissions on config files. The default is set to the current default, that is, world readable config files.
Specifying the `config_mode` parameter enables one to restrict permissions to disallow `other` from reading the config files.

#### This Pull Request (PR) fixes the following issues
Fixes #249
