### PR TITLE
Some updates to be able to use an internal http mirror with proxy to download the .tar.gz archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,26 @@ The directory to install kafka to.
 
 The url where the kafka is downloaded from.
 
+##### `mirror_subpath`
+
+The url subpath where the kafka is downloaded from (default value: `/kafka/{version}`).
+
+##### `proxy_port`
+
+The proxy port where the kafka is downloaded from.
+
+##### `proxy_host`
+
+The proxy host where the kafka is downloaded from.
+
+##### `proxy_server`
+
+The proxy server where the kafka is downloaded from (to use instead of `proxy_port` and `proxy_host` if you need to set an url as proxy for example).
+
+##### `proxy_type`
+
+The proxy type where the kafka is downloaded from (`http` for example).
+
 ##### `install_java`
 
 Install java if it's not already installed.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,9 +21,14 @@ class kafka::params {
   $bin_dir        = '/opt/kafka/bin'
   $log_dir        = '/var/log/kafka'
   $mirror_url     = 'http://mirrors.ukfast.co.uk/sites/ftp.apache.org'
+  $mirror_subpath = "/kafka/${version}"
   $install_java   = false
   $package_dir    = '/var/tmp/kafka'
   $package_name   = undef
+  $proxy_server   = undef
+  $proxy_host     = undef
+  $proxy_port     = undef
+  $proxy_type     = undef
   $package_ensure = 'present'
   $user           = 'kafka'
   $group          = 'kafka'
@@ -34,6 +39,7 @@ class kafka::params {
   $manage_user    = true
   $manage_group   = true
   $config_mode    = '0644'
+  $install_mode   = '0755'
 
   $service_install = true
   $service_ensure = 'running'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Adding proxy settings in params and a configurable subpath to be able to download the kafka tgz archive from an internal http mirror url (we've got this constraint on our project).

Build and tests results: https://travis-ci.org/idrissneumann/puppet-kafka/builds

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
