### PR TITLE
Match params of init script with the ones of systemd unit

### DIFF
--- a/spec/classes/broker_spec.rb
+++ b/spec/classes/broker_spec.rb
@@ -56,6 +56,26 @@ describe 'kafka::broker', type: :class do
       context 'defaults' do
         it { is_expected.to contain_file('/etc/init.d/kafka') }
 
+        context 'limit_nofile set' do
+          let :params do
+            {
+              limit_nofile: '65536'
+            }
+          end
+
+          it { is_expected.to contain_file('/etc/init.d/kafka').with_content %r{ulimit -n 65536$} }
+        end
+
+        context 'limit_core set' do
+          let :params do
+            {
+              limit_core: 'infinity'
+            }
+          end
+
+          it { is_expected.to contain_file('/etc/init.d/kafka').with_content %r{ulimit -c infinity$} }
+        end
+
         it { is_expected.to contain_service('kafka') }
       end
     end

--- a/templates/init.erb
+++ b/templates/init.erb
@@ -50,9 +50,17 @@ if [ -f /etc/default/kafka ]; then
 fi
 
 start() {
-  ulimit -n 65536
+
+  <% if @limit_nofile -%>
+  ulimit -n <%= @limit_nofile %>
+  <% end -%>
+
+  <% if @limit_core -%>
+  ulimit -c <%= @limit_core %>
+  <% end -%>
+
   ulimit -s 10240
-  ulimit -c unlimited
+
   if [ -f "$PID_FILE" ]; then
     PID=`cat "$PID_FILE"`
     if [ `ps -p "$PID" -o pid= || echo 1` -eq `ps ax | grep -i "$PGREP_PATTERN" | grep -v grep | awk '{print $1}' || echo 2` ] ; then


### PR DESCRIPTION
#### Pull Request (PR) description

Adds the same ulimit settings in the init script as the ones that are already present in systemd unit file.

#### This Pull Request (PR) fixes the following issues

Improve #226

