### PR TITLE
Drop Puppet 4 Support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -61,7 +61,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 6.0.0"
+      "version_requirement": ">= 5.5.8 < 7.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
Puppet 4 is EOL, and as per https://voxpupuli.org/blog/2019/01/03/dropping-puppet4 we are removing explicit support for it.