### PR TITLE
Update default version to 2.4.1 with scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ script:
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.1.9
-    bundler_args: --without system_tests development release
-    env: PUPPET_VERSION="~> 4.0" CHECK=test PARALLEL_TEST_PROCESSORS=12
   - rvm: 2.4.4
     bundler_args: --without system_tests development release
     env: PUPPET_VERSION="~> 5.0" CHECK=test
@@ -34,6 +31,12 @@ matrix:
   - rvm: 2.5.1
     bundler_args: --without development release
     dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos6-64{hypervisor=docker} CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.5.1
+    bundler_args: --without development release
+    dist: trusty
     env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos7-64{hypervisor=docker} CHECK=beaker
     services: docker
     sudo: required
@@ -47,6 +50,36 @@ matrix:
     bundler_args: --without development release
     dist: trusty
     env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=debian9-64{hypervisor=docker} CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.5.1
+    bundler_args: --without development release
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=ubuntu1604-64{hypervisor=docker} CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.5.1
+    bundler_args: --without development release
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos6-64{hypervisor=docker} CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.5.1
+    bundler_args: --without development release
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos7-64{hypervisor=docker} CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.5.1
+    bundler_args: --without development release
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=debian8-64{hypervisor=docker} CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.5.1
+    bundler_args: --without development release
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=debian9-64{hypervisor=docker} CHECK=beaker
     services: docker
     sudo: required
 branches:

--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,8 @@ def location_for(place, fake_version = nil)
 end
 
 group :test do
-  gem 'puppetlabs_spec_helper', '~> 2.6',                           :require => false
-  gem 'rspec-puppet', '~> 2.5',                                     :require => false
-  gem 'rspec-puppet-facts',                                         :require => false
+  gem 'puppetlabs_spec_helper', '>= 2.14.0',                        :require => false
+  gem 'rspec-puppet-facts', '>= 1.9.5',                             :require => false
   gem 'rspec-puppet-utils',                                         :require => false
   gem 'puppet-lint-leading_zero-check',                             :require => false
   gem 'puppet-lint-trailing_comma-check',                           :require => false
@@ -23,12 +22,11 @@ group :test do
   gem 'puppet-lint-variable_contains_upcase',                       :require => false
   gem 'metadata-json-lint',                                         :require => false
   gem 'redcarpet',                                                  :require => false
-  gem 'rubocop', '~> 0.49.1',                                       :require => false if RUBY_VERSION >= '2.3.0'
-  gem 'rubocop-rspec', '~> 1.15.0',                                 :require => false if RUBY_VERSION >= '2.3.0'
+  gem 'rubocop', '~> 0.49.1',                                       :require => false
+  gem 'rubocop-rspec', '~> 1.15.0',                                 :require => false
   gem 'mocha', '~> 1.4.0',                                          :require => false
   gem 'coveralls',                                                  :require => false
   gem 'simplecov-console',                                          :require => false
-  gem 'rack', '~> 1.0',                                             :require => false if RUBY_VERSION < '2.2.2'
   gem 'parallel_tests',                                             :require => false
 end
 
@@ -44,7 +42,7 @@ group :system_tests do
   if beaker_version = ENV['BEAKER_VERSION']
     gem 'beaker', *location_for(beaker_version)
   else
-    gem 'beaker', '>= 3.9.0', :require => false
+    gem 'beaker', '>= 4.2.0', :require => false
   end
   if beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION']
     gem 'beaker-rspec', *location_for(beaker_rspec_version)
@@ -52,19 +50,22 @@ group :system_tests do
     gem 'beaker-rspec',  :require => false
   end
   gem 'serverspec',                         :require => false
-  gem 'beaker-hostgenerator', '>= 1.1.10',  :require => false
+  gem 'beaker-hostgenerator', '>= 1.1.22',  :require => false
+  gem 'beaker-docker',                      :require => false
+  gem 'beaker-puppet',                      :require => false
   gem 'beaker-puppet_install_helper',       :require => false
   gem 'beaker-module_install_helper',       :require => false
-  gem 'rbnacl', '~> 4',                     :require => false if RUBY_VERSION >= '2.2.6'
-  gem 'rbnacl-libsodium',                   :require => false if RUBY_VERSION >= '2.2.6'
+  gem 'rbnacl', '>= 4',                     :require => false
+  gem 'rbnacl-libsodium',                   :require => false
   gem 'bcrypt_pbkdf',                       :require => false
+  gem 'ed25519',                            :require => false
 end
 
 group :release do
-  gem 'github_changelog_generator',  :require => false, :git => 'https://github.com/skywinder/github-changelog-generator' if RUBY_VERSION >= '2.2.2'
+  gem 'github_changelog_generator',  :require => false, :git => 'https://github.com/voxpupuli/github-changelog-generator', :branch => 'voxpupuli_essential_fixes'
   gem 'puppet-blacksmith',           :require => false
-  gem 'voxpupuli-release',           :require => false, :git => 'https://github.com/voxpupuli/voxpupuli-release-gem'
-  gem 'puppet-strings', '>= 1.0',    :require => false
+  gem 'voxpupuli-release',           :require => false
+  gem 'puppet-strings', '>= 2.2',    :require => false
 end
 
 
@@ -75,7 +76,7 @@ else
   gem 'facter', :require => false, :groups => [:test]
 end
 
-ENV['PUPPET_VERSION'].nil? ? puppetversion = '~> 5.0' : puppetversion = ENV['PUPPET_VERSION'].to_s
+ENV['PUPPET_VERSION'].nil? ? puppetversion = '~> 6.0' : puppetversion = ENV['PUPPET_VERSION'].to_s
 gem 'puppet', puppetversion, :require => false, :groups => [:test]
 
 # vim: syntax=ruby

--- a/README.md
+++ b/README.md
@@ -343,12 +343,13 @@ This module only supports Kafka >= 0.9.0.0.
 
 This module is tested on the following platforms:
 
-* CentOS 5
 * CentOS 6
-* Ubuntu 12.04
-* Ubuntu 14.04
+* CentOS 7
+* Ubuntu 16.04
+* Debian 8
+* Debian 9
 
-It is tested with the OSS version of Puppet (>= 4.7.0) only.
+It is tested with the OSS version of Puppet (>= 5.5) only.
 
 ## Development
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,8 +14,8 @@ class kafka::params {
   unless $facts['os']['family'] =~ /(RedHat|Debian)/ {
     warning("${facts['os']['family']} is not supported")
   }
-  $version        = '0.11.0.3'
-  $scala_version  = '2.11'
+  $version        = '2.4.1'
+  $scala_version  = '2.12'
   $install_dir    = "/opt/kafka-${scala_version}-${version}"
   $config_dir     = '/opt/kafka/config'
   $bin_dir        = '/opt/kafka/bin'
@@ -61,16 +61,13 @@ class kafka::params {
   $broker_opts       = ''
 
   $mirror_heap_opts  = '-Xmx256M'
-  $mirror_jmx_opts   = '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false \
-  -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9991'
+  $mirror_jmx_opts   = '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9991'
   $mirror_log4j_opts = $broker_log4j_opts
 
-  $producer_jmx_opts   = '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false \
-  -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9992'
+  $producer_jmx_opts   = '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9992'
   $producer_log4j_opts = $broker_log4j_opts
 
-  $consumer_jmx_opts   = '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false \
-  -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9993'
+  $consumer_jmx_opts   = '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9993'
   $consumer_log4j_opts = $broker_log4j_opts
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -61,7 +61,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 6.0.0"
+      "version_requirement": ">= 4.10.0 < 7.0.0"
     }
   ],
   "tags": [

--- a/spec/acceptance/01_zookeeper_spec.rb
+++ b/spec/acceptance/01_zookeeper_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper_acceptance'
+
+describe 'zookeeper prereq' do
+  zookeeper = <<-EOS
+    if $::osfamily == 'RedHat' {
+      class { 'java' :
+        package => 'java-1.8.0-openjdk-devel',
+      }
+
+      exec { 'create pid dir':
+        command => '/bin/mkdir -p /var/run/',
+        creates => '/var/run/',
+      }
+
+      file { '/var/run/zookeeper/':
+        ensure => directory,
+        owner  => 'zookeeper',
+        group  => 'zookeeper',
+      }
+
+      $zookeeper_service_provider = $facts['os']['release']['major'] ? {
+        '6' => 'redhat',
+        '7' => 'systemd',
+      }
+
+      class { 'zookeeper':
+        install_method      => 'archive',
+        archive_version     => '3.6.0',
+        service_provider    => $zookeeper_service_provider,
+        manage_service_file => true,
+      }
+    } else {
+      include zookeeper
+    }
+  EOS
+
+  it 'installs zookeeper with no errors' do
+    apply_manifest(zookeeper, catch_failures: true)
+    apply_manifest(zookeeper, catch_changes: true)
+  end
+end

--- a/spec/acceptance/consumer_spec.rb
+++ b/spec/acceptance/consumer_spec.rb
@@ -3,11 +3,10 @@ require 'spec_helper_acceptance'
 describe 'kafka::consumer' do
   it 'works with no errors' do
     pp = <<-EOS
-      class { 'zookeeper': } ->
       class { 'kafka::consumer':
         service_config => {
-          topic     => 'demo',
-          zookeeper => 'localhost:2181',
+          topic            => 'demo',
+          bootstrap-server => 'localhost:9092',
         },
       }
     EOS
@@ -20,11 +19,10 @@ describe 'kafka::consumer' do
     context 'with default parameters' do
       it 'works with no errors' do
         pp = <<-EOS
-          class { 'zookeeper': } ->
           class { 'kafka::consumer':
             service_config => {
-              topic     => 'demo',
-              zookeeper => 'localhost:2181',
+              topic            => 'demo',
+              bootstrap-server => 'localhost:9092',
             },
           }
         EOS
@@ -48,14 +46,14 @@ describe 'kafka::consumer' do
         it { is_expected.to be_grouped_into 'kafka' }
       end
 
-      describe file('/opt/kafka-2.11-0.11.0.3') do
+      describe file('/opt/kafka-2.12-2.4.1') do
         it { is_expected.to be_directory }
         it { is_expected.to be_owned_by 'kafka' }
         it { is_expected.to be_grouped_into 'kafka' }
       end
 
       describe file('/opt/kafka') do
-        it { is_expected.to be_linked_to('/opt/kafka-2.11-0.11.0.3') }
+        it { is_expected.to be_linked_to('/opt/kafka-2.12-2.4.1') }
       end
 
       describe file('/opt/kafka/config') do
@@ -76,11 +74,10 @@ describe 'kafka::consumer' do
     context 'with default parameters' do
       it 'works with no errors' do
         pp = <<-EOS
-          class { 'zookeeper': } ->
           class { 'kafka::consumer':
             service_config => {
-              topic     => 'demo',
-              zookeeper => 'localhost:2181',
+              topic            => 'demo',
+              bootstrap-server => 'localhost:9092',
             },
           }
         EOS
@@ -100,11 +97,10 @@ describe 'kafka::consumer' do
     context 'with custom config_dir' do
       it 'works with no errors' do
         pp = <<-EOS
-          class { 'zookeeper': } ->
           class { 'kafka::consumer':
             service_config => {
-              topic     => 'demo',
-              zookeeper => 'localhost:2181',
+              topic            => 'demo',
+              bootstrap-server => 'localhost:9092',
             },
             config_dir => '/opt/kafka/custom_config',
           }
@@ -125,11 +121,10 @@ describe 'kafka::consumer' do
     context 'with default parameters' do
       it 'works with no errors' do
         pp = <<-EOS
-          class { 'zookeeper': } ->
           class { 'kafka::consumer':
             service_config => {
-              topic     => 'demo',
-              zookeeper => 'localhost:2181',
+              topic            => 'demo',
+              bootstrap-server => 'localhost:9092',
             },
           }
         EOS
@@ -141,15 +136,15 @@ describe 'kafka::consumer' do
         it { is_expected.to be_file }
         it { is_expected.to be_owned_by 'root' }
         it { is_expected.to be_grouped_into 'root' }
-        it { is_expected.to contain 'export KAFKA_JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false' }
-        it { is_expected.to contain 'export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/log4j.properties"' }
+        it { is_expected.to contain 'export KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9993"' }
+        it { is_expected.to contain 'export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:/opt/kafka/config/log4j.properties"' }
       end
 
       describe file('/etc/systemd/system/kafka-consumer.service'), if: (fact('operatingsystemmajrelease') == '7' && fact('osfamily') == 'RedHat') do
         it { is_expected.to be_file }
         it { is_expected.to be_owned_by 'root' }
         it { is_expected.to be_grouped_into 'root' }
-        it { is_expected.to contain 'Environment=\'KAFKA_JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false' }
+        it { is_expected.to contain 'Environment=\'KAFKA_JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9993\'' }
         it { is_expected.to contain 'Environment=\'KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:/opt/kafka/config/log4j.properties\'' }
       end
 

--- a/spec/acceptance/hieradata/RedHat.yaml
+++ b/spec/acceptance/hieradata/RedHat.yaml
@@ -1,4 +1,0 @@
-zookeeper::repo: 'cloudera'
-zookeeper::cdhver: 5
-zookeeper::initialize_datastore: true
-

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -36,14 +36,14 @@ describe 'kafka' do
         it { is_expected.to be_grouped_into 'kafka' }
       end
 
-      describe file('/opt/kafka-2.11-0.11.0.3') do
+      describe file('/opt/kafka-2.12-2.4.1') do
         it { is_expected.to be_directory }
         it { is_expected.to be_owned_by 'kafka' }
         it { is_expected.to be_grouped_into 'kafka' }
       end
 
       describe file('/opt/kafka') do
-        it { is_expected.to be_linked_to('/opt/kafka-2.11-0.11.0.3') }
+        it { is_expected.to be_linked_to('/opt/kafka-2.12-2.4.1') }
       end
 
       describe file('/opt/kafka/config') do
@@ -63,7 +63,7 @@ describe 'kafka' do
       it 'works with no errors' do
         pp = <<-EOS
           class { 'kafka':
-            version => '1.1.0',
+            version => '2.4.0',
           }
         EOS
 
@@ -86,14 +86,14 @@ describe 'kafka' do
         it { is_expected.to be_grouped_into 'kafka' }
       end
 
-      describe file('/opt/kafka-2.11-1.1.0') do
+      describe file('/opt/kafka-2.12-2.4.0') do
         it { is_expected.to be_directory }
         it { is_expected.to be_owned_by 'kafka' }
         it { is_expected.to be_grouped_into 'kafka' }
       end
 
       describe file('/opt/kafka') do
-        it { is_expected.to be_linked_to('/opt/kafka-2.11-1.1.0') }
+        it { is_expected.to be_linked_to('/opt/kafka-2.12-2.4.0') }
       end
 
       describe file('/opt/kafka/config') do
@@ -113,7 +113,7 @@ describe 'kafka' do
       it 'works with no errors' do
         pp = <<-EOS
           class { 'kafka':
-            scala_version => '2.11',
+            scala_version => '2.13',
           }
         EOS
 
@@ -136,14 +136,14 @@ describe 'kafka' do
         it { is_expected.to be_grouped_into 'kafka' }
       end
 
-      describe file('/opt/kafka-2.11-0.11.0.3') do
+      describe file('/opt/kafka-2.13-2.4.1') do
         it { is_expected.to be_directory }
         it { is_expected.to be_owned_by 'kafka' }
         it { is_expected.to be_grouped_into 'kafka' }
       end
 
       describe file('/opt/kafka') do
-        it { is_expected.to be_linked_to('/opt/kafka-2.11-0.11.0.3') }
+        it { is_expected.to be_linked_to('/opt/kafka-2.13-2.4.1') }
       end
 
       describe file('/opt/kafka/config') do
@@ -186,14 +186,14 @@ describe 'kafka' do
         it { is_expected.to be_grouped_into 'kafka' }
       end
 
-      describe file('/opt/kafka-2.11-0.11.0.3') do
+      describe file('/opt/kafka-2.12-2.4.1') do
         it { is_expected.to be_directory }
         it { is_expected.to be_owned_by 'kafka' }
         it { is_expected.to be_grouped_into 'kafka' }
       end
 
       describe file('/opt/kafka') do
-        it { is_expected.to be_linked_to('/opt/kafka-2.11-0.11.0.3') }
+        it { is_expected.to be_linked_to('/opt/kafka-2.12-2.4.1') }
       end
 
       describe file('/opt/kafka/custom_config') do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -22,7 +22,7 @@ describe 'kafka', type: :class do
         it { is_expected.to contain_user('kafka') }
 
         it { is_expected.to contain_file('/var/tmp/kafka') }
-        it { is_expected.to contain_file('/opt/kafka-2.11-0.11.0.3') }
+        it { is_expected.to contain_file('/opt/kafka-2.12-2.4.1') }
         it { is_expected.to contain_file('/opt/kafka') }
         it { is_expected.to contain_file('/opt/kafka/config') }
         it { is_expected.to contain_file('/var/log/kafka') }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -16,9 +16,11 @@ RSpec.configure do |c|
       if host[:platform] =~ %r{el-7-x86_64} && host[:hypervisor] =~ %r{docker}
         on(host, "sed -i '/nodocs/d' /etc/yum.conf")
       end
-
-      write_hiera_config_on(host, ['%<::osfamily>s'])
-      copy_hiera_data_to(host, './spec/acceptance/hieradata/')
+      next unless fact('os.name') == 'Debian' && fact('os.release.major') == '8'
+      on host, 'echo "deb http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list'
+      on host, 'echo \'Acquire::Check-Valid-Until "false";\' > /etc/apt/apt.conf.d/check-valid'
+      on host, 'DEBIAN_FRONTEND=noninteractive apt-get -y update'
+      on host, 'DEBIAN_FRONTEND=noninteractive apt-get install -y -t jessie-backports openjdk-8-jdk'
     end
   end
 end

--- a/templates/init.erb
+++ b/templates/init.erb
@@ -55,7 +55,7 @@ start() {
   ulimit -c unlimited
   if [ -f "$PID_FILE" ]; then
     PID=`cat "$PID_FILE"`
-    if [ `ps -p "$PID" -o pid= || echo 1` -eq `pgrep -f "$PGREP_PATTERN" || echo 2` ] ; then
+    if [ `ps -p "$PID" -o pid= || echo 1` -eq `ps ax | grep -i "$PGREP_PATTERN" | grep -v grep | awk '{print $1}' || echo 2` ] ; then
       echo "$PID_FILE exists, process is already running"
       exit 0
     fi
@@ -67,7 +67,7 @@ start() {
 
   /bin/su "$KAFKA_USER" -c "KAFKA_JMX_OPTS=\"$KAFKA_JMX_OPTS\" $DAEMON $DAEMON_OPTS<%- if @service_name == 'kafka-producer' -%> $PRODUCER_INPUT<%- end -%> >/dev/null 2>&1 &"
   sleep 2
-  PID=`pgrep -f "$PGREP_PATTERN"`
+  PID=`ps ax | grep -i "$PGREP_PATTERN" | grep -v grep | awk '{print $1}'`
   if [ -z "$PID" ]; then
     echo "$NAME could not be started"
     exit 1
@@ -81,7 +81,7 @@ start() {
 stop() {
   if ! [ -f "$PID_FILE" ]; then
     echo -n "$PID_FILE does not exist"
-    if PID=`pgrep -f "$PGREP_PATTERN"` ; then
+    if PID=`ps ax | grep -i "$PGREP_PATTERN" | grep -v grep | awk '{print $1}'` ; then
       echo -n ", but process is running"
       echo "$PID" > "$PID_FILE"
     else
@@ -97,7 +97,7 @@ stop() {
   # wait until the process is finished
   RETRIES=0
   MAX_RETRIES=10
-  while [ ! -z `pgrep -f "$PGREP_PATTERN"` ]; do
+  while [ ! -z `ps ax | grep -i "$PGREP_PATTERN" | grep -v grep | awk '{print $1}'` ]; do
     sleep 1
     RETRIES=$((RETRIES+1))
     if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
@@ -117,7 +117,7 @@ status() {
   fi
 
   PID=`cat "$PID_FILE"`
-  if ! [ `ps -p "$PID" -o pid= || echo 1` -eq `pgrep -f "$PGREP_PATTERN" || echo 2` ] ; then
+  if ! [ `ps -p "$PID" -o pid= || echo 1` -eq `ps ax | grep -i "$PGREP_PATTERN" | grep -v grep | awk '{print $1}' || echo 2` ] ; then
     echo "$NAME stopped but pid file exists"
     exit 1
   fi


### PR DESCRIPTION
The old versions are no longer downloadable from the default download location.
Updating to the latest version is a breaking change.

`pgrep -f` in init.d was changed due to a [4096 character limitation.](https://unix.stackexchange.com/questions/570819/pgrep-f-matches-on-first-4096-characters-only?noredirect=1)

Acceptance tests have been fixed up and testing is now also done on CentOS 6.
A lot of the effort was getting the zookeeper module to work.

Tests aren't necessarily that brilliant, (eg. multi-node tests would be better), but at least they pass now.