### PR TITLE
Drop Puppet 4 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-kafka",
-  "version": "5.3.1-rc0",
+  "version": "6.0.0-rc0",
   "author": "Vox Pupuli",
   "summary": "Puppet module for Kafka",
   "license": "MIT",
@@ -61,7 +61,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 7.0.0"
+      "version_requirement": ">= 5.5.8 < 7.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
In line with Vox Pupuli [policy](https://voxpupuli.org/blog/2019/01/03/dropping-puppet4/), we'll be dropping support for Puppet 4 in the next major release.