### PR TITLE
Use latest available version of ZooKeeper in acceptance tests

### DIFF
--- a/spec/acceptance/01_zookeeper_spec.rb
+++ b/spec/acceptance/01_zookeeper_spec.rb
@@ -25,7 +25,7 @@ describe 'zookeeper prereq' do
 
       class { 'zookeeper':
         install_method      => 'archive',
-        archive_version     => '3.6.0',
+        archive_version     => '3.6.1',
         service_provider    => $zookeeper_service_provider,
         manage_service_file => true,
       }


### PR DESCRIPTION
Version 3.6.0 of ZooKeeper has been archived:
* https://downloads.apache.org/zookeeper/
* https://archive.apache.org/dist/zookeeper/

Fixes #307, #308 