### PR TITLE
No longer accept deprecated String params

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1577,7 +1577,7 @@ Default value: ''
 
 ##### `replication_factor`
 
-Data type: `Variant[Integer,String[1]]`
+Data type: `Integer`
 
 The replication factor for each partition in the topic being created. If
 not supplied, defaults to the cluster default.
@@ -1586,7 +1586,7 @@ Default value: 1
 
 ##### `partitions`
 
-Data type: `Variant[Integer,String[1]]`
+Data type: `Integer`
 
 The number of partitions for the topic being created or altered. If not
 supplied for create, defaults to the cluster default.

--- a/manifests/topic.pp
+++ b/manifests/topic.pp
@@ -32,20 +32,13 @@
 #   See the Kafka documentation for full details on the topic configs.
 #
 define kafka::topic (
-  String[1] $ensure                              = '',
-  String[1] $zookeeper                           = '',
-  Variant[Integer,String[1]] $replication_factor = 1,
-  Variant[Integer,String[1]] $partitions         = 1,
-  String[1] $bin_dir                             = '/opt/kafka/bin',
-  Optional[Hash[String[1],String[1]]] $config    = undef,
+  String[1] $ensure                           = '',
+  String[1] $zookeeper                        = '',
+  Integer   $replication_factor               = 1,
+  Integer   $partitions                       = 1,
+  String[1] $bin_dir                          = '/opt/kafka/bin',
+  Optional[Hash[String[1],String[1]]] $config = undef,
 ) {
-  if is_string($replication_factor) {
-    deprecation('kafka::topic', 'Please use Integer type, not String, for paramter replication_factor')
-  }
-  if is_string($partitions) {
-    deprecation('kafka::topic', 'Please use Integer type, not String, for paramter partitions')
-  }
-
   $_zookeeper          = "--zookeeper ${zookeeper}"
   $_replication_factor = "--replication-factor ${replication_factor}"
   $_partitions         = "--partitions ${partitions}"

--- a/spec/defines/topic_spec.rb
+++ b/spec/defines/topic_spec.rb
@@ -13,8 +13,8 @@ describe 'kafka::topic', type: :define do
           {
             'ensure'             => 'present',
             'zookeeper'          => 'localhost:2181',
-            'replication_factor' => '1',
-            'partitions'         => '1'
+            'replication_factor' => 1,
+            'partitions'         => 1
           }
         end
 


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes the warning

```
Warning: This method is deprecated, please use match expressions with Stdlib::Compat::String instead. 
They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions. 
at ["/opt/puppetlabs/puppet/modules/kafka/manifests/topic.pp", 43]:
```

Syntax is supported from Puppet 5.5 to 7.3, so there shouldn't be any problems.