### PR TITLE
Removing SystemD reloading step

### DIFF
--- a/manifests/broker/service.pp
+++ b/manifests/broker/service.pp
@@ -50,8 +50,7 @@ class kafka::broker::service (
       }
 
       File["/etc/systemd/system/${service_name}.service"]
-      ~> Exec['systemctl-daemon-reload']
-      -> Service[$service_name]
+      ~> Service[$service_name]
     } else {
       file { "/etc/init.d/${service_name}":
         ensure  => file,

--- a/manifests/consumer/service.pp
+++ b/manifests/consumer/service.pp
@@ -50,8 +50,7 @@ class kafka::consumer::service (
       }
 
       File["/etc/systemd/system/${service_name}.service"]
-      ~> Exec['systemctl-daemon-reload']
-      -> Service[$service_name]
+      ~> Service[$service_name]
     } else {
       file { "/etc/init.d/${service_name}":
         ensure  => file,

--- a/manifests/mirror/service.pp
+++ b/manifests/mirror/service.pp
@@ -47,8 +47,7 @@ class kafka::mirror::service (
       }
 
       File["/etc/systemd/system/${service_name}.service"]
-      ~> Exec['systemctl-daemon-reload']
-      -> Service[$service_name]
+      ~> Service[$service_name]
     } else {
       file { "/etc/init.d/${service_name}":
         ensure  => file,

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 0.4.0 < 3.0.0"
+      "version_requirement": ">= 0.4.0 <= 3.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 0.4.0 <= 3.0.0"
+      "version_requirement": ">= 0.4.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/broker_spec.rb
+++ b/spec/classes/broker_spec.rb
@@ -45,12 +45,10 @@ describe 'kafka::broker', type: :class do
         context 'defaults' do
           if os_facts[:service_provider] == 'systemd'
             it { is_expected.to contain_file('/etc/init.d/kafka').with_ensure('absent') }
-            it { is_expected.to contain_file('/etc/systemd/system/kafka.service').that_notifies('Exec[systemctl-daemon-reload]') }
             it { is_expected.to contain_file('/etc/systemd/system/kafka.service').with_content %r{^After=network\.target syslog\.target$} }
             it { is_expected.to contain_file('/etc/systemd/system/kafka.service').with_content %r{^Wants=network\.target syslog\.target$} }
             it { is_expected.not_to contain_file('/etc/systemd/system/kafka.service').with_content %r{^LimitNOFILE=} }
             it { is_expected.not_to contain_file('/etc/systemd/system/kafka.service').with_content %r{^LimitCORE=} }
-            it { is_expected.to contain_exec('systemctl-daemon-reload').that_comes_before('Service[kafka]') }
           else
             it { is_expected.to contain_file('/etc/init.d/kafka') }
           end

--- a/spec/classes/consumer_spec.rb
+++ b/spec/classes/consumer_spec.rb
@@ -38,8 +38,6 @@ describe 'kafka::consumer', type: :class do
         context 'defaults' do
           if os_facts[:service_provider] == 'systemd'
             it { is_expected.to contain_file('/etc/init.d/kafka-consumer').with_abent('absent') }
-            it { is_expected.to contain_file('/etc/systemd/system/kafka-consumer.service').that_notifies('Exec[systemctl-daemon-relad]') }
-            it { is_expected.to contain_exec('systemctl-daemon-reload').that_comes_before('Service[kafka-consumer]') }
           else
             it { is_expected.to contain_file('/etc/init.d/kafka-consumer') }
           end

--- a/spec/classes/mirror_spec.rb
+++ b/spec/classes/mirror_spec.rb
@@ -42,9 +42,7 @@ describe 'kafka::mirror', type: :class do
         context 'defaults' do
           if os_facts[:service_provider] == 'systemd'
             it { is_expected.to contain_file('/etc/init.d/kafka-mirror').with_ensure('absent') }
-            it { is_expected.to contain_file('/etc/systemd/system/kafka-mirror.service').that_notifies('Exec[systemctl-daemon-reload]') }
             it { is_expected.to contain_file('/etc/systemd/system/kafka-mirror.service').with_content %r{/opt/kafka/config/(?=.*consumer)|(?=.*producer).propertie} }
-            it { is_expected.to contain_exec('systemctl-daemon-reload').that_comes_before('Service[kafka-mirror]') }
           else
             it { is_expected.to contain_file('/etc/init.d/kafka-mirror') }
             it { is_expected.to contain_file('/etc/init.d/kafka-mirror').with_content %r{/opt/kafka/config/(?=.*consumer)|(?=.*producer).properties} }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/
-->

Removing SystemD reloading step by a special class from the camptocamp/systemd module, because the class was deprecated by the change [171](https://github.com/camptocamp/puppet-systemd/pull/171)

#### This Pull Request (PR) fixes the following issues
Fixes #324

