### PR TITLE
Support kafka 3.0 topics

### DIFF
--- a/spec/defines/topic_spec.rb
+++ b/spec/defines/topic_spec.rb
@@ -25,6 +25,39 @@ describe 'kafka::topic', type: :define do
         }
       end
 
+      context 'when create topic demo for kafka v3' do
+        let(:title) { 'demo' }
+        let :params do
+          {
+            'ensure'             => 'present',
+            'bootstrap_server'   => 'localhost:9092',
+            'replication_factor' => 1,
+            'partitions'         => 1
+          }
+        end
+
+        it {
+          is_expected.to contain_exec('create topic demo').with(
+            command: 'kafka-topics.sh --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 1 --topic demo '
+          )
+        }
+      end
+
+      context 'when create topic without zookeeper or bootstrap_server' do
+        let(:title) { 'demo' }
+        let :params do
+          {
+            'ensure'             => 'present',
+            'replication_factor' => 1,
+            'partitions'         => 1
+          }
+        end
+
+        it {
+          is_expected.to compile.and_raise_error(%r{Either zookeeper or bootstrap_server parameter must be defined!})
+        }
+      end
+
       context 'when create topic demo with config' do
         let(:title) { 'demo' }
         let :params do


### PR DESCRIPTION
#### Pull Request (PR) description

In kafka 3.0 the `--zookeeper` option was removed for topics. It was deprecated in v2.2.0 (March 2019) and `--bootstrap-server` has been available since then. I'm unsure if we should replace `zookeeper` with `bootstrap-server` completely or allow both options, but in that case I don't know how to require at least one of both arguments. Open for discussion here.

#### This Pull Request (PR) fixes the following issues
Fixes #302
