### PR TITLE
Rely on voxpupuli-test to mock the service_provider fact

### DIFF
--- a/spec/classes/broker_spec.rb
+++ b/spec/classes/broker_spec.rb
@@ -6,8 +6,6 @@ require 'shared_examples_param_validation'
 describe 'kafka::broker', type: :class do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      os_facts = os_facts.merge({ service_provider: 'systemd' })
-
       let(:facts) do
         os_facts
       end
@@ -60,7 +58,7 @@ describe 'kafka::broker', type: :class do
         end
 
         context 'defaults' do
-          if os_facts[:service_provider] == 'systemd'
+          if os_facts['service_provider'] == 'systemd'
             it { is_expected.to contain_file('/etc/init.d/kafka').with_ensure('absent') }
             it { is_expected.not_to contain_file('/etc/systemd/system/kafka.service').with_content %r{^LimitNOFILE=} }
             it { is_expected.not_to contain_file('/etc/systemd/system/kafka.service').with_content %r{^LimitCORE=} }
@@ -74,7 +72,7 @@ describe 'kafka::broker', type: :class do
         context 'limit_nofile set' do
           let(:params) { super().merge(limit_nofile: '65536') }
 
-          if os_facts[:service_provider] == 'systemd'
+          if os_facts['service_provider'] == 'systemd'
             it { is_expected.to contain_file('/etc/systemd/system/kafka.service').with_content %r{^LimitNOFILE=65536$} }
           else
             it { is_expected.to contain_file('/etc/init.d/kafka').with_content %r{ulimit -n 65536$} }
@@ -84,14 +82,14 @@ describe 'kafka::broker', type: :class do
         context 'limit_core set' do
           let(:params) { super().merge(limit_core: 'infinity') }
 
-          if os_facts[:service_provider] == 'systemd'
+          if os_facts['service_provider'] == 'systemd'
             it { is_expected.to contain_file('/etc/systemd/system/kafka.service').with_content %r{^LimitCORE=infinity$} }
           else
             it { is_expected.to contain_file('/etc/init.d/kafka').with_content %r{ulimit -c infinity$} }
           end
         end
 
-        context 'service_requires set', if: os_facts[:service_provider] == 'systemd' do
+        context 'service_requires set', if: os_facts['service_provider'] == 'systemd' do
           let(:params) { super().merge(service_requires: ['dummy.target']) }
 
           it { is_expected.to contain_file('/etc/systemd/system/kafka.service').with_content %r{^After=dummy\.target$} }

--- a/spec/classes/consumer_spec.rb
+++ b/spec/classes/consumer_spec.rb
@@ -6,8 +6,6 @@ require 'shared_examples_param_validation'
 describe 'kafka::consumer', type: :class do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      os_facts = os_facts.merge({ service_provider: 'systemd' })
-
       let(:facts) do
         os_facts
       end
@@ -53,7 +51,7 @@ describe 'kafka::consumer', type: :class do
 
       describe 'kafka::consumer::service' do
         context 'defaults' do
-          if os_facts[:service_provider] == 'systemd'
+          if os_facts['service_provider'] == 'systemd'
             it { is_expected.to contain_file('/etc/systemd/system/kafka-consumer.service') }
           else
             it { is_expected.to contain_file('/etc/init.d/kafka-consumer') }

--- a/spec/classes/mirror_spec.rb
+++ b/spec/classes/mirror_spec.rb
@@ -6,8 +6,6 @@ require 'shared_examples_param_validation'
 describe 'kafka::mirror', type: :class do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      os_facts = os_facts.merge({ service_provider: 'systemd' })
-
       let(:facts) do
         os_facts
       end
@@ -50,7 +48,7 @@ describe 'kafka::mirror', type: :class do
 
       describe 'kafka::mirror::service' do
         context 'defaults' do
-          if os_facts[:service_provider] == 'systemd'
+          if os_facts['service_provider'] == 'systemd'
             it { is_expected.to contain_file('/etc/init.d/kafka-mirror').with_ensure('absent') }
             it { is_expected.to contain_file('/etc/systemd/system/kafka-mirror.service').with_content %r{/opt/kafka/config/(?=.*consumer)|(?=.*producer).propertie} }
           else

--- a/spec/classes/producer_spec.rb
+++ b/spec/classes/producer_spec.rb
@@ -6,8 +6,6 @@ require 'shared_examples_param_validation'
 describe 'kafka::producer', type: :class do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      os_facts = os_facts.merge({ service_provider: 'systemd' })
-
       let(:facts) do
         os_facts
       end
@@ -22,7 +20,7 @@ describe 'kafka::producer', type: :class do
         }
       end
 
-      if os_facts[:service_provider] == 'systemd'
+      if os_facts['service_provider'] == 'systemd'
         it { is_expected.to compile.and_raise_error(%r{Console Producer is not supported on systemd, because the stdin of the process cannot be redirected}) }
       else
         it { is_expected.to contain_class('kafka::producer::install').that_comes_before('Class[kafka::producer::config]') }

--- a/spec/classes/producer_spec.rb
+++ b/spec/classes/producer_spec.rb
@@ -23,7 +23,7 @@ describe 'kafka::producer', type: :class do
       end
 
       if os_facts[:service_provider] == 'systemd'
-        it { is_expected.to raise_error(Puppet::Error, %r{Console Producer is not supported on systemd, because the stdin of the process cannot be redirected}) }
+        it { is_expected.to compile.and_raise_error(%r{Console Producer is not supported on systemd, because the stdin of the process cannot be redirected}) }
       else
         it { is_expected.to contain_class('kafka::producer::install').that_comes_before('Class[kafka::producer::config]') }
         it { is_expected.to contain_class('kafka::producer::config').that_comes_before('Class[kafka::producer::service]') }


### PR DESCRIPTION
Custom facts in rspec-puppet-facts are strings, not symbols. This is inconsistent with other facts and confusing and will be fixed in the next major version of rspec-puppet-facts.

This was reported in https://github.com/voxpupuli/voxpupuli-test/issues/124.