### PR TITLE
Feature/command config

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1648,7 +1648,7 @@ Default value: `$kafka::params::producer_log4j_opts`
 
 ### <a name="kafka--topic"></a>`kafka::topic`
 
-This defined type handles the creation of Kafka topics.
+   altering broker configs (e.g. specify sasl and ssl configs)
 
 #### Examples
 
@@ -1674,6 +1674,7 @@ The following parameters are available in the `kafka::topic` defined type:
 * [`partitions`](#-kafka--topic--partitions)
 * [`bin_dir`](#-kafka--topic--bin_dir)
 * [`config`](#-kafka--topic--config)
+* [`cmd_config`](#-kafka--topic--cmd_config)
 
 ##### <a name="-kafka--topic--ensure"></a>`ensure`
 
@@ -1732,6 +1733,15 @@ Data type: `Optional[Hash[String[1],String[1]]]`
 
 A topic configuration override for the topic being created or altered.
 See the Kafka documentation for full details on the topic configs.
+
+Default value: `undef`
+
+##### <a name="-kafka--topic--cmd_config"></a>`cmd_config`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+Property file containing configs to be passed to Admin Client.
+This is used only with --bootstrap-server option for describing and
 
 Default value: `undef`
 

--- a/spec/defines/topic_spec.rb
+++ b/spec/defines/topic_spec.rb
@@ -78,6 +78,25 @@ describe 'kafka::topic', type: :define do
           )
         }
       end
+
+      context 'when create topic demo for kafka v3 and command-config' do
+        let(:title) { 'demo' }
+        let :params do
+          {
+            'ensure'             => 'present',
+            'bootstrap_server'   => 'localhost:9092',
+            'replication_factor' => 1,
+            'partitions'         => 1,
+            'cmd_config'         => '/opt/kafka/config/admin.config',
+          }
+        end
+
+        it {
+          is_expected.to contain_exec('create topic demo').with(
+            command: 'kafka-topics.sh --create --bootstrap-server localhost:9092 --command-config /opt/kafka/config/admin.config --replication-factor 1 --partitions 1 --topic demo '
+          )
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
If kafka has been configured with SASL and self-signed SSL certificates and using zookeeper is not an options (kraft is being used), you need to pass `--command-config` in order to be able to manage topics.

`/opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka01.example.com:9093 --command-config /opt/kafka/config/admin.config --describe`

`/opt/kafka/config/admin.config`:

```
sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="<%= $kafka_admin_user %>" password="<%= $kafka_admin_password %>";
security.protocol=SASL_SSL
sasl.mechanism=PLAIN
<%- if $self_signed_certs { -%>
ssl.truststore.location=<%= $kafka_keystore_path %>
ssl.truststore.password=<%= $jks_password %>
ssl.truststore.type=JKS
<%- } -%>
```
