### PR TITLE
fix systemd unit Invalid URL (Documentation)

### DIFF
--- a/manifests/broker/service.pp
+++ b/manifests/broker/service.pp
@@ -61,7 +61,7 @@ class kafka::broker::service (
 
     $unit_entry = {
       'Description'   => 'Apache Kafka server (broker)',
-      'Documentation' => 'Documentation=http://kafka.apache.org/documentation.html',
+      'Documentation' => 'http://kafka.apache.org/documentation.html',
       'After'         => $service_requires.empty ? {
         true    => undef,
         default => $service_requires,


### PR DESCRIPTION
```
$systemctl cat kafka
# Deployed with puppet
#

[Unit]
Description=Apache Kafka server (broker)
Documentation=Documentation=http://kafka.apache.org/documentation.html
```

```
 /etc/systemd/system/kafka.service:6: Invalid URL, ignoring: Documentation=http://kafka.apache.org/documentation.html
```
